### PR TITLE
Add ability to set session data

### DIFF
--- a/android/src/main/java/com/alaminkarno/flutter_crisp_chat/FlutterCrispChatPlugin.java
+++ b/android/src/main/java/com/alaminkarno/flutter_crisp_chat/FlutterCrispChatPlugin.java
@@ -79,7 +79,22 @@ public class FlutterCrispChatPlugin implements FlutterPlugin, MethodCallHandler,
             }
         } else if (call.method.equals("resetCrispChatSession")) {
             Crisp.resetChatSession(context);
-        } else {
+        } else if (call.method.equals("setSessionString")) {
+            HashMap<String, Object> args = (HashMap<String, Object>) call.arguments;
+            if (args != null) {
+                String key = (String) args.get("key");
+                String value = (String) args.get("value");
+                Crisp.setSessionString(key, value);
+            }
+        } else if (call.method.equals("setSessionInt")) {
+            HashMap<String, Object> args = (HashMap<String, Object>) call.arguments;
+            if (args != null) {
+                String key = (String) args.get("key");
+                int value = (int) args.get("value");
+                Crisp.setSessionInt(key, value);
+            }
+        }
+        else {
             result.notImplemented();
         }
     }

--- a/android/src/main/java/com/alaminkarno/flutter_crisp_chat/FlutterCrispChatPlugin.kt
+++ b/android/src/main/java/com/alaminkarno/flutter_crisp_chat/FlutterCrispChatPlugin.kt
@@ -66,6 +66,24 @@ class FlutterCrispChatPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             "resetCrispChatSession" -> {
                 Crisp.resetChatSession(context)
             }
+            
+            "setSessionString" -> {
+                val args = call.arguments as HashMap<String?, Any?>
+                if (args != null) {
+                    val key = args["key"] as String
+                    val value = args["value"] as String
+                    Crisp.setSessionString(key, value)
+                }
+            }
+
+            "setSessionInt" -> {
+                val args = call.arguments as HashMap<String?, Any?>
+                if (args != null) {
+                    val key = args["key"] as String
+                    val value = args["value"] as Int
+                    Crisp.setSessionInt(key, value)
+                }
+            }
 
             else -> result.notImplemented()
         }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Crisp (1.1.0)
-  - crisp_chat (2.0.2):
+  - crisp_chat (2.0.3):
     - Crisp
     - Flutter
   - Flutter (1.0.0)
@@ -21,7 +21,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Crisp: b88f081c87566254e603d885dcdbc97596ade755
-  crisp_chat: 7c9ad85fd65f49a26cc63df028dd3d8c8c97a05c
+  crisp_chat: 2a726a86ce1c796388db27c80f0f49c423b7c260
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
 
 PODFILE CHECKSUM: a69b4e639ad4e65c02c4d8b5b17642141111f056

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,7 +61,9 @@ class _MyAppState extends State<MyApp> {
             children: [
               ElevatedButton(
                 onPressed: () async {
-                  await FlutterCrispChat.openCrispChat(config: config);
+                  FlutterCrispChat.openCrispChat(config: config);
+                  FlutterCrispChat.setSessionString(key: "a_string", value: "string_value");
+                  FlutterCrispChat.setSessionInt(key: "a_number", value: 12345);
                 },
                 child: const Text('Open Crisp Chat'),
               ),

--- a/ios/Classes/SwiftFlutterCrispChatPlugin.swift
+++ b/ios/Classes/SwiftFlutterCrispChatPlugin.swift
@@ -42,6 +42,28 @@ public class SwiftFlutterCrispChatPlugin: NSObject, FlutterPlugin, UIApplication
         else if call.method == "resetCrispChatSession" {
             CrispSDK.session.reset()
         }
+        else if call.method == "setSessionString" {
+            guard let args = call.arguments as? [String: Any],
+              let key = args["key"] as? String,
+              let value = args["value"] as? String else {
+                let errorMessage = "Expected key of type String and value of type String."
+                result(FlutterError(code: "INVALID_ARGUMENTS", message: errorMessage, details: nil))
+                return
+            }
+            CrispSDK.session.setString(value, forKey: key)
+            result(nil)
+        }
+        else if call.method == "setSessionInt" {
+            guard let args = call.arguments as? [String: Any],
+              let key = args["key"] as? String,
+              let value = args["value"] as? Int else {
+                let errorMessage = "Expected key of type String and value of type Int."
+                result(FlutterError(code: "INVALID_ARGUMENTS", message: errorMessage, details: nil))
+                return
+            }
+            CrispSDK.session.setInt(value, forKey: key)
+            result(nil)
+        }
         else {
             result(FlutterMethodNotImplemented)
         }

--- a/lib/crisp_chat.dart
+++ b/lib/crisp_chat.dart
@@ -22,4 +22,15 @@ class FlutterCrispChat {
   static Future<void> resetCrispChatSession() {
     return FlutterCrispChatPlatform.instance.resetCrispChatSession();
   }
+
+  /// [setSessionString]  is to set session data string
+  static void setSessionString({required String key, required String value}) {
+    FlutterCrispChatPlatform.instance.setSessionString(key: key, value: value);
+  }
+
+  /// [setSessionInt]  is to set session data int
+  static void setSessionInt({required String key, required int value}) {
+    FlutterCrispChatPlatform.instance.setSessionInt(key: key, value: value);
+  }
+
 }

--- a/lib/src/flutter_crisp_chat_method_channel.dart
+++ b/lib/src/flutter_crisp_chat_method_channel.dart
@@ -24,4 +24,25 @@ class MethodChannelFlutterCrispChat extends FlutterCrispChatPlatform {
   Future<void> resetCrispChatSession() async {
     await methodChannel.invokeMethod('resetCrispChatSession');
   }
+
+  /// [setSessionString] is used to invoke the Method Channel and call native
+  /// code with arguments `key` and `value`.
+  @override
+  void setSessionString({required String key, required String value}) {
+    methodChannel.invokeMethod('setSessionString', <String, String>{
+      'key': key,
+      'value': value,
+    });
+  }
+
+  /// [setSessionInt] is used to invoke the Method Channel and call native
+  /// code with arguments `key` and `value`.
+  @override
+  void setSessionInt({required String key, required int value}) {
+    methodChannel.invokeMethod('setSessionInt', <String, dynamic>{
+      'key': key,
+      'value': value,
+    });
+  }
+
 }

--- a/lib/src/flutter_crisp_chat_platform_interface.dart
+++ b/lib/src/flutter_crisp_chat_platform_interface.dart
@@ -35,4 +35,17 @@ abstract class FlutterCrispChatPlatform extends PlatformInterface {
   Future<void> resetCrispChatSession() {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
+
+  /// [setSessionString] is to call native platform and if no implementation
+  /// found through error.
+  void setSessionString({required String key, required String value}) {
+    throw UnimplementedError('platformVersion() has not been implemented.');
+  }
+
+  /// [setSessionInt] is to call native platform and if no implementation
+  /// found through error.
+  void setSessionInt({required String key, required int value}) {
+    throw UnimplementedError('platformVersion() has not been implemented.');
+  }
+ 
 }

--- a/test/flutter_crisp_chat_test.dart
+++ b/test/flutter_crisp_chat_test.dart
@@ -17,6 +17,18 @@ class MockFlutterCrispChatPlatform
     //
     throw UnimplementedError();
   }
+
+  @override
+  Future<void> setSessionString({required String key, required String value}) {
+    //
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> setSessionInt({required String key, required int value}) {
+    //
+    throw UnimplementedError();
+  }
 }
 
 void main() {


### PR DESCRIPTION
This pull request adds the ability to set session data by adding two new methods: `setSessionString` and `setSessionInt`. These methods allow devs to store string and integer data within a session as described in the [Crisp SDK Documentation](https://docs.crisp.chat/guides/chatbox-sdks/android-sdk/#availables-apis)

## Changes:
- Added setSessionString method to set string session data.
- Added setSessionInt method to set integer session data.

## Testing:
``` dart
FlutterCrispChat.openCrispChat(config: config);
FlutterCrispChat.setSessionString(key: "a_string", value: "string_value");
FlutterCrispChat.setSessionInt(key: "a_number", value: 12345);
```
<img width="932" alt="image" src="https://github.com/user-attachments/assets/6a9c3832-9acd-4b89-ba4f-c98e6ce1f6fa">
