### PR TITLE
fix: resolve conflict in `application:didFinishLaunchingWithOptions:` method for `UIApplicationDelegate` conformance

### DIFF
--- a/ios/Classes/SwiftFlutterCrispChatPlugin.swift
+++ b/ios/Classes/SwiftFlutterCrispChatPlugin.swift
@@ -115,17 +115,20 @@ public class SwiftFlutterCrispChatPlugin: NSObject, FlutterPlugin, UIApplication
        completionHandler()
     }
 
-    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    @objc(application:didFinishLaunchingWithOptions:)
+    public func application(_ application: UIApplication,
+                            didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let center = UNUserNotificationCenter.current()
         center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
             if granted {
                 DispatchQueue.main.async {
-                        application.registerForRemoteNotifications()
+                    application.registerForRemoteNotifications()
                 }
             }
         }
         center.delegate = self
         return true
     }
+
 }
 


### PR DESCRIPTION
fix: resolve conflict in `application:didFinishLaunchingWithOptions:` method for `UIApplicationDelegate` conformance

- Added `@objc` attribute to explicitly mark `didFinishLaunchingWithOptions` as Objective-C method.
- Ensured proper conformance to `UIApplicationDelegate`.
- Resolved Swift compiler error caused by method conflict.
