### PR TITLE
Feat: implement setSessionSegments on Android and iOS

### DIFF
--- a/android/src/main/java/com/alaminkarno/flutter_crisp_chat/FlutterCrispChatPlugin.java
+++ b/android/src/main/java/com/alaminkarno/flutter_crisp_chat/FlutterCrispChatPlugin.java
@@ -10,6 +10,7 @@ import androidx.annotation.NonNull;
 import com.alaminkarno.flutter_crisp_chat.config.CrispConfig;
 
 import java.util.HashMap;
+import java.util.List;
 
 import im.crisp.client.external.ChatActivity;
 import im.crisp.client.external.Crisp;
@@ -98,12 +99,18 @@ public class FlutterCrispChatPlugin implements FlutterPlugin, MethodCallHandler,
                 Crisp.setSessionInt(key, value);
             }
         } else if (call.method.equals("getSessionIdentifier")) {
-
             String sessionId = Crisp.getSessionIdentifier(context);
             if (sessionId != null) {
                 result.success(sessionId);
             } else {
                 result.error("NO_SESSION", "No active session found", null);
+            }
+        } else if (call.method.equals("setSessionSegments")) {
+            HashMap<String, Object> args = (HashMap<String, Object>) call.arguments;
+            if (args != null) {
+                List<String> segments = (List<String>) args.get("segments");
+                boolean overwrite = (boolean) args.get("overwrite");
+                Crisp.setSessionSegments(segments, overwrite);
             }
         }
         else {

--- a/ios/Classes/SwiftFlutterCrispChatPlugin.swift
+++ b/ios/Classes/SwiftFlutterCrispChatPlugin.swift
@@ -98,7 +98,19 @@ public class SwiftFlutterCrispChatPlugin: NSObject, FlutterPlugin, UIApplication
             } else {
                 result(FlutterError(code: "NO_SESSION", message: "No active session found", details: nil))
             }
-
+            
+        case "setSessionSegments":
+            // Sets session segment
+            guard let args = call.arguments as? [String: Any],
+                  let segments = args["segments"] as? [String],
+                  let overwrite = args["overwrite"] as? Bool else {
+                result(FlutterError(code: "INVALID_ARGUMENTS", message: "Expected segments of type String and overwrite of type Bool.", details: nil))
+                return
+            }
+            
+            let previousSegments = CrispSDK.session.segments
+            CrispSDK.session.segments = overwrite ? segments : (previousSegments ?? []) + segments
+            result(nil)
         default:
             // Handles unimplemented method calls
             result(FlutterMethodNotImplemented)

--- a/lib/crisp_chat.dart
+++ b/lib/crisp_chat.dart
@@ -70,4 +70,12 @@ class FlutterCrispChat {
       return null;
     }
   }
+
+  /// [setSessionSegments] Sets a collection of session segments
+  /// and optionally overwrite existing ones (default is false)
+  static void setSessionSegments(
+      {required List<String> segments, bool overwrite = false}) {
+    FlutterCrispChatPlatform.instance
+        .setSessionSegments(segments: segments, overwrite: overwrite);
+  }
 }

--- a/lib/src/flutter_crisp_chat_method_channel.dart
+++ b/lib/src/flutter_crisp_chat_method_channel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 
 import 'config.dart';
 import 'flutter_crisp_chat_platform_interface.dart';
@@ -56,5 +57,16 @@ class MethodChannelFlutterCrispChat extends FlutterCrispChatPlatform {
       debugPrint("Failed to get session identifier: '${e.message}'.");
       return null;
     }
+  }
+
+  /// [setSessionSegments] Sets a collection of session segments
+  /// and optionally overwrite existing ones (default is false)
+  @override
+  void setSessionSegments(
+      {required List<String> segments, bool overwrite = false}) {
+    methodChannel.invokeMethod('setSessionSegments', <String, dynamic>{
+      'segments': segments,
+      'overwrite': overwrite,
+    });
   }
 }

--- a/lib/src/flutter_crisp_chat_platform_interface.dart
+++ b/lib/src/flutter_crisp_chat_platform_interface.dart
@@ -53,4 +53,11 @@ abstract class FlutterCrispChatPlatform extends PlatformInterface {
     throw UnimplementedError(
         'getSessionIdentifier() has not been implemented.');
   }
+
+  /// [setSessionSegments] Sets a collection of session segments
+  /// and optionally overwrite existing ones (default is false)
+  void setSessionSegments(
+      {required List<String> segments, bool overwrite = false}) {
+    throw UnimplementedError('setSessionSegments() has not been implemented.');
+  }
 }

--- a/test/flutter_crisp_chat_test.dart
+++ b/test/flutter_crisp_chat_test.dart
@@ -34,6 +34,12 @@ class MockFlutterCrispChatPlatform
   Future<String?> getSessionIdentifier() {
     throw UnimplementedError();
   }
+
+  @override
+  void setSessionSegments(
+      {required List<String> segments, bool overwrite = false}) {
+    throw UnimplementedError();
+  }
 }
 
 void main() {


### PR DESCRIPTION
I introduced the setSessionSegments method to support clients using multiple segments with Crisp.

Initially, I considered updating the segment parameter in the configuration to accept a List<String> instead of a single String. However, this would have introduced a breaking change.

By adding setSessionSegments, users can now manage multiple segments dynamically without affecting existing implementations.