### PR TITLE
feat(iOS): integrate full Crisp push notification support and refine chat session management

### DIFF
--- a/ios/Classes/SwiftFlutterCrispChatPlugin.swift
+++ b/ios/Classes/SwiftFlutterCrispChatPlugin.swift
@@ -63,7 +63,10 @@ public class SwiftFlutterCrispChatPlugin: NSObject, FlutterPlugin, UIApplication
             CrispSDK.user.company = crispConfig.user?.company?.toCrispCompany()
 
             // Present the chat view controller on the root view controller
-            if let viewController = UIApplication.shared.windows.first?.rootViewController {
+            if let viewController = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .flatMap({ $0.windows })
+                .first(where: { $0.isKeyWindow })?.rootViewController {
                 viewController.present(ChatViewController(), animated: true)
             }
 

--- a/ios/Classes/SwiftFlutterCrispChatPlugin.swift
+++ b/ios/Classes/SwiftFlutterCrispChatPlugin.swift
@@ -20,6 +20,9 @@ public class SwiftFlutterCrispChatPlugin: NSObject, FlutterPlugin, UIApplication
         instance.channel = channel
         registrar.addMethodCallDelegate(instance, channel: channel)
         registrar.addApplicationDelegate(instance)
+
+        // Set UNUserNotificationCenter delegate
+        UNUserNotificationCenter.current().delegate = instance
     }
 
     /// Handles method calls from Flutter to native iOS.
@@ -63,6 +66,8 @@ public class SwiftFlutterCrispChatPlugin: NSObject, FlutterPlugin, UIApplication
             if let viewController = UIApplication.shared.windows.first?.rootViewController {
                 viewController.present(ChatViewController(), animated: true)
             }
+
+            result(nil)
 
         case "resetCrispChatSession":
             // Resets the current Crisp chat session
@@ -115,6 +120,15 @@ public class SwiftFlutterCrispChatPlugin: NSObject, FlutterPlugin, UIApplication
             // Handles unimplemented method calls
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    /// Called when app finishes launching — registers for remote notifications
+    public func application(_ application: UIApplication,
+                            didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        DispatchQueue.main.async {
+            UIApplication.shared.registerForRemoteNotifications()
+        }
+        return true
     }
 
     /// Handles registration of device token for push notifications.


### PR DESCRIPTION
feat(iOS): integrate full Crisp push notification support and refine chat session management

- Added remote notification registration in application launch
- Handled device token registration via CrispSDK.setDeviceToken
- Implemented Crisp push notification handling in foreground and background
- Set UNUserNotificationCenter delegate to receive push callbacks
- Improved rootViewController detection for presenting Crisp chat
- Cleaned up and organized method channel logic for better readability
