### PR TITLE
feat: Add tests for pushSessionEvent

### DIFF
--- a/android/src/main/java/com/alaminkarno/flutter_crisp_chat/FlutterCrispChatPlugin.java
+++ b/android/src/main/java/com/alaminkarno/flutter_crisp_chat/FlutterCrispChatPlugin.java
@@ -11,6 +11,7 @@ import com.alaminkarno.flutter_crisp_chat.config.CrispConfig;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 
 import im.crisp.client.external.ChatActivity;
 import im.crisp.client.external.Crisp;
@@ -24,11 +25,9 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
-/// [FlutterCrispChatPlugin] using [FlutterPlugin], [MethodCallHandler] and [ActivityAware]
-/// to handling Method Channel Callback from Flutter and Open new Activity.
-
 /**
- * FlutterCrispChatPlugin
+ * [FlutterCrispChatPlugin] using [FlutterPlugin], [MethodCallHandler] and [ActivityAware]
+ * to handling Method Channel Callback from Flutter and Open new Activity.
  */
 public class FlutterCrispChatPlugin implements FlutterPlugin, MethodCallHandler, ActivityAware {
 
@@ -128,15 +127,24 @@ public class FlutterCrispChatPlugin implements FlutterPlugin, MethodCallHandler,
             }
         } else if (call.method.equals("pushSessionEvent")) {
             HashMap<String, Object> args = (HashMap<String, Object>) call.arguments;
+
             if (args != null) {
                 String name = (String) args.get("name");
+                if (name == null || name.isEmpty()) {
+                    result.error("INVALID_ARGUMENTS", "Missing 'name' argument", null);
+                    return;
+                }
+
+                String colorString = (String) args.get("color");
+                Color eventColor = parseColorOrDefault(colorString, Color.BLUE);
+
                 im.crisp.client.external.data.SessionEvent event =
-                        new im.crisp.client.external.data.SessionEvent(name, Color.GREEN);
+                        new im.crisp.client.external.data.SessionEvent(name, eventColor);
 
                 Crisp.pushSessionEvent(event);
                 result.success(null);
             } else {
-                result.notImplemented();
+                result.error("INVALID_ARGUMENTS", "Arguments must be a map", null);
             }
         }
         else {
@@ -187,6 +195,31 @@ public class FlutterCrispChatPlugin implements FlutterPlugin, MethodCallHandler,
             activity.startActivity(intent);
         } else {
             context.startActivity(intent);
+        }
+    }
+
+    private Color parseColorOrDefault(String colorString, Color defaultColor) {
+        if (colorString == null) {
+            return defaultColor;
+        }
+
+        String safeColor = colorString.toLowerCase(Locale.ROOT);
+
+        switch (safeColor) {
+            case "black": return Color.BLACK;
+            case "blue": return Color.BLUE;
+            case "brown": return Color.BROWN;
+            case "green": return Color.GREEN;
+            case "grey":
+            case "gray": return Color.GREY;
+            case "orange": return Color.ORANGE;
+            case "pink": return Color.PINK;
+            case "purple": return Color.PURPLE;
+            case "red": return Color.RED;
+            case "yellow": return Color.YELLOW;
+            default:
+                Log.w("CrispSDK", "Unknown color: " + safeColor + ". Using default color.");
+                return defaultColor;
         }
     }
 

--- a/android/src/main/java/com/alaminkarno/flutter_crisp_chat/FlutterCrispChatPlugin.java
+++ b/android/src/main/java/com/alaminkarno/flutter_crisp_chat/FlutterCrispChatPlugin.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import im.crisp.client.external.ChatActivity;
 import im.crisp.client.external.Crisp;
+import im.crisp.client.external.data.SessionEvent.Color;
 
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
@@ -121,6 +122,18 @@ public class FlutterCrispChatPlugin implements FlutterPlugin, MethodCallHandler,
                 List<String> segments = (List<String>) args.get("segments");
                 boolean overwrite = (boolean) args.get("overwrite");
                 Crisp.setSessionSegments(segments, overwrite);
+                result.success(null);
+            } else {
+                result.notImplemented();
+            }
+        } else if (call.method.equals("pushSessionEvent")) {
+            HashMap<String, Object> args = (HashMap<String, Object>) call.arguments;
+            if (args != null) {
+                String name = (String) args.get("name");
+                im.crisp.client.external.data.SessionEvent event =
+                        new im.crisp.client.external.data.SessionEvent(name, Color.GREEN);
+
+                Crisp.pushSessionEvent(event);
                 result.success(null);
             } else {
                 result.notImplemented();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -131,6 +131,13 @@ class _MyAppState extends State<MyApp> {
                     value: 12345,
                   );
 
+                  await Future.delayed(Duration(seconds: 1), () {
+                    FlutterCrispChat.pushSessionEvent(
+                      name: 'test_event',
+                      color: SessionEventColor.green,
+                    );
+                  });
+
                   /// Checking session ID After 5 sec
                   await Future.delayed(const Duration(seconds: 5), () async {
                     String? sessionId =

--- a/ios/Classes/SwiftFlutterCrispChatPlugin.swift
+++ b/ios/Classes/SwiftFlutterCrispChatPlugin.swift
@@ -119,6 +119,18 @@ public class SwiftFlutterCrispChatPlugin: NSObject, FlutterPlugin, UIApplication
             let previousSegments = CrispSDK.session.segments
             CrispSDK.session.segments = overwrite ? segments : (previousSegments ?? []) + segments
             result(nil)
+
+        case "pushSessionEvent":
+            // Pushes a session event to Crisp
+            guard let args = call.arguments as? [String: Any],
+                  let name = args["name"] as? String else {
+                result(FlutterError(code: "INVALID_ARGUMENTS", message: "Expected at least 'name' of type String.", details: nil))
+                return
+            }
+            
+            let event = SessionEvent(name: name, color: .blue)
+            CrispSDK.session.pushEvents([event])
+            result(nil)
         default:
             // Handles unimplemented method calls
             result(FlutterMethodNotImplemented)

--- a/ios/Classes/SwiftFlutterCrispChatPlugin.swift
+++ b/ios/Classes/SwiftFlutterCrispChatPlugin.swift
@@ -121,14 +121,33 @@ public class SwiftFlutterCrispChatPlugin: NSObject, FlutterPlugin, UIApplication
             result(nil)
 
         case "pushSessionEvent":
-            // Pushes a session event to Crisp
             guard let args = call.arguments as? [String: Any],
                   let name = args["name"] as? String else {
                 result(FlutterError(code: "INVALID_ARGUMENTS", message: "Expected at least 'name' of type String.", details: nil))
                 return
             }
+
+            var eventColor: SessionEventColor = .blue
+
+            if let colorString = args["color"] as? String {
+                switch colorString.lowercased() {
+                case "black": eventColor = .black
+                case "blue": eventColor = .blue
+                case "brown": eventColor = .brown
+                case "green": eventColor = .green
+                case "grey": eventColor = .grey
+                case "orange": eventColor = .orange
+                case "pink": eventColor = .pink
+                case "purple": eventColor = .purple
+                case "red": eventColor = .red
+                case "yellow": eventColor = .yellow
+                default:
+                    print("Invalid color string: \(colorString). Using default: .blue")
+                    eventColor = .blue
+                }
+            }
             
-            let event = SessionEvent(name: name, color: .blue)
+            let event = SessionEvent(name: name, color: eventColor)
             CrispSDK.session.pushEvents([event])
             result(nil)
         default:

--- a/lib/crisp_chat.dart
+++ b/lib/crisp_chat.dart
@@ -129,11 +129,22 @@ class FlutterCrispChat {
     );
   }
 
-  /// Pushes a session event to Crisp.
+  /// [pushSessionEvent] sends a custom event to the Crisp session.
+  /// This can be used to log specific actions or milestones
+  /// within the chat session, such as user interactions or significant
+  /// events that occur during the chat.
   ///
-  /// [event] is a map describing the event (type, name, color, etc).
-  /// This method proxies the call to the native platform implementation.
-  static Future<void> pushSessionEvent(Map<String, dynamic> event) {
-    return FlutterCrispChatPlatform.instance.pushSessionEvent(event);
+  /// {@category Session Events}
+  /// @param name The name of the event to log.
+  /// @param color The color associated with the event, used for visual
+  ///              differentiation in the Crisp dashboard. Defaults to `SessionEventColor.blue`.
+  static Future<void> pushSessionEvent({
+    required String name,
+    SessionEventColor color = SessionEventColor.blue,
+  }) {
+    return FlutterCrispChatPlatform.instance.pushSessionEvent(
+      name: name,
+      color: color,
+    );
   }
 }

--- a/lib/crisp_chat.dart
+++ b/lib/crisp_chat.dart
@@ -128,4 +128,12 @@ class FlutterCrispChat {
       overwrite: overwrite,
     );
   }
+
+  /// Pushes a session event to Crisp.
+  ///
+  /// [event] is a map describing the event (type, name, color, etc).
+  /// This method proxies the call to the native platform implementation.
+  static Future<void> pushSessionEvent(Map<String, dynamic> event) {
+    return FlutterCrispChatPlatform.instance.pushSessionEvent(event);
+  }
 }

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -233,3 +233,22 @@ class GeoLocation {
     };
   }
 }
+
+/// Represents the color options for session events in Crisp chat.
+/// This enum is used to categorize events visually in the chat interface.
+/// Each color corresponds to a specific color used in the Crisp chat UI.
+/// The colors are used to differentiate events and provide a visual cue
+/// to users and support agents.
+/// {@category Configuration}
+enum SessionEventColor {
+  black,
+  blue,
+  brown,
+  green,
+  grey,
+  orange,
+  pink,
+  purple,
+  red,
+  yellow,
+}

--- a/lib/src/flutter_crisp_chat_method_channel.dart
+++ b/lib/src/flutter_crisp_chat_method_channel.dart
@@ -50,8 +50,9 @@ class MethodChannelFlutterCrispChat extends FlutterCrispChatPlatform {
   @override
   Future<String?> getSessionIdentifier() async {
     try {
-      final sessionId =
-          await methodChannel.invokeMethod<String>('getSessionIdentifier');
+      final sessionId = await methodChannel.invokeMethod<String>(
+        'getSessionIdentifier',
+      );
       return sessionId;
     } on PlatformException catch (e) {
       debugPrint("Failed to get session identifier: '${e.message}'.");
@@ -66,17 +67,22 @@ class MethodChannelFlutterCrispChat extends FlutterCrispChatPlatform {
     required List<String> segments,
     bool overwrite = false,
   }) {
-    methodChannel.invokeMethod(
-      'setSessionSegments',
-      <String, dynamic>{
-        'segments': segments,
-        'overwrite': overwrite,
-      },
-    );
+    methodChannel.invokeMethod('setSessionSegments', <String, dynamic>{
+      'segments': segments,
+      'overwrite': overwrite,
+    });
   }
 
+  /// [pushSessionEvent] is used to invoke the Method Channel and call native
+  /// code with arguments `name` and `color`.
   @override
-  Future<void> pushSessionEvent(Map<String, dynamic> event) async {
-    await methodChannel.invokeMethod('pushSessionEvent', event);
+  Future<void> pushSessionEvent({
+    required String name,
+    SessionEventColor color = SessionEventColor.blue,
+  }) async {
+    await methodChannel.invokeMethod('pushSessionEvent', <String, dynamic>{
+      'name': name,
+      'color': color.name.toString(),
+    });
   }
 }

--- a/lib/src/flutter_crisp_chat_method_channel.dart
+++ b/lib/src/flutter_crisp_chat_method_channel.dart
@@ -74,4 +74,9 @@ class MethodChannelFlutterCrispChat extends FlutterCrispChatPlatform {
       },
     );
   }
+
+  @override
+  Future<void> pushSessionEvent(Map<String, dynamic> event) async {
+    await methodChannel.invokeMethod('pushSessionEvent', event);
+  }
 }

--- a/lib/src/flutter_crisp_chat_platform_interface.dart
+++ b/lib/src/flutter_crisp_chat_platform_interface.dart
@@ -62,4 +62,10 @@ abstract class FlutterCrispChatPlatform extends PlatformInterface {
   }) {
     throw UnimplementedError('setSessionSegments() has not been implemented.');
   }
+
+  /// Pushes a session event to Crisp.
+  /// [event] is a map describing the event (type, name, color, etc).
+  Future<void> pushSessionEvent(Map<String, dynamic> event) {
+    throw UnimplementedError('pushSessionEvent() has not been implemented.');
+  }
 }

--- a/lib/src/flutter_crisp_chat_platform_interface.dart
+++ b/lib/src/flutter_crisp_chat_platform_interface.dart
@@ -63,9 +63,13 @@ abstract class FlutterCrispChatPlatform extends PlatformInterface {
     throw UnimplementedError('setSessionSegments() has not been implemented.');
   }
 
-  /// Pushes a session event to Crisp.
-  /// [event] is a map describing the event (type, name, color, etc).
-  Future<void> pushSessionEvent(Map<String, dynamic> event) {
+  /// [pushSessionEvent] pushes a session event to the native platform.
+  /// /// [name] is the name of the event, and [color] is the color associated with
+  /// the event, defaulting to blue.
+  Future<void> pushSessionEvent({
+    required String name,
+    SessionEventColor color = SessionEventColor.blue,
+  }) {
     throw UnimplementedError('pushSessionEvent() has not been implemented.');
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ documentation: https://pub.dev/documentation/crisp_chat/latest/
 
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=2.15.0 <4.0.0'
   flutter: ">=2.5.0"
 
 dependencies:

--- a/test/flutter_crisp_chat_test.dart
+++ b/test/flutter_crisp_chat_test.dart
@@ -43,15 +43,25 @@ class MockFlutterCrispChatPlatform
 
   Map<String, dynamic>? setSessionSegmentsArgs;
   @override
-  void setSessionSegments(
-      {required List<String> segments, bool overwrite = false}) {
+  void setSessionSegments({
+    required List<String> segments,
+    bool overwrite = false,
+  }) {
     setSessionSegmentsArgs = {'segments': segments, 'overwrite': overwrite};
+  }
+
+  Map<String, dynamic>? setSessionAttributesArgs;
+  @override
+  Future<void> pushSessionEvent({
+    required String name,
+    SessionEventColor color = SessionEventColor.blue,
+  }) async {
+    setSessionAttributesArgs = {'name': name, 'color': color};
   }
 }
 
 void main() {
-  final FlutterCrispChatPlatform initialPlatform =
-      FlutterCrispChatPlatform.instance;
+  final initialPlatform = FlutterCrispChatPlatform.instance;
 
   CrispConfig config = CrispConfig(websiteID: "YOUR_WEBSITE_KEY");
 
@@ -76,23 +86,25 @@ void main() {
 
   group('setSessionString', () {
     test('calls platform method with correct arguments', () {
-      MockFlutterCrispChatPlatform fakePlatform = MockFlutterCrispChatPlatform();
+      MockFlutterCrispChatPlatform fakePlatform =
+          MockFlutterCrispChatPlatform();
       FlutterCrispChatPlatform.instance = fakePlatform;
 
       FlutterCrispChat.setSessionString(key: 'testKey', value: 'testValue');
-      expect(fakePlatform.setSessionStringArgs, equals({'key': 'testKey', 'value': 'testValue'}));
+      expect(fakePlatform.setSessionStringArgs,
+          equals({'key': 'testKey', 'value': 'testValue'}));
     });
 
     test('throws ArgumentError for empty key', () {
       expect(
-            () => FlutterCrispChat.setSessionString(key: '', value: 'testValue'),
+        () => FlutterCrispChat.setSessionString(key: '', value: 'testValue'),
         throwsA(isA<ArgumentError>()),
       );
     });
 
     test('throws ArgumentError for empty value', () {
       expect(
-            () => FlutterCrispChat.setSessionString(key: 'testKey', value: ''),
+        () => FlutterCrispChat.setSessionString(key: 'testKey', value: ''),
         throwsA(isA<ArgumentError>()),
       );
     });
@@ -100,60 +112,105 @@ void main() {
 
   group('setSessionInt', () {
     test('calls platform method with correct arguments', () {
-      MockFlutterCrispChatPlatform fakePlatform = MockFlutterCrispChatPlatform();
+      MockFlutterCrispChatPlatform fakePlatform =
+          MockFlutterCrispChatPlatform();
       FlutterCrispChatPlatform.instance = fakePlatform;
 
       FlutterCrispChat.setSessionInt(key: 'testKey', value: 123);
-      expect(fakePlatform.setSessionIntArgs, equals({'key': 'testKey', 'value': 123}));
+      expect(fakePlatform.setSessionIntArgs,
+          equals({'key': 'testKey', 'value': 123}));
     });
 
     test('throws ArgumentError for empty key', () {
       expect(
-            () => FlutterCrispChat.setSessionInt(key: '', value: 123),
+        () => FlutterCrispChat.setSessionInt(key: '', value: 123),
         throwsA(isA<ArgumentError>()),
       );
     });
   });
 
   group('getSessionIdentifier', () {
-    test('returns session ID from platform', () async {
-      MockFlutterCrispChatPlatform fakePlatform = MockFlutterCrispChatPlatform();
-      fakePlatform.mockSessionId = 'testSessionId';
-      FlutterCrispChatPlatform.instance = fakePlatform;
+    test(
+      'returns session ID from platform',
+      () async {
+        final fakePlatform = MockFlutterCrispChatPlatform();
+        fakePlatform.mockSessionId = 'testSessionId';
+        FlutterCrispChatPlatform.instance = fakePlatform;
 
-      final sessionId = await FlutterCrispChat.getSessionIdentifier();
-      expect(sessionId, 'testSessionId');
-    });
+        final sessionId = await FlutterCrispChat.getSessionIdentifier();
+        expect(sessionId, 'testSessionId');
+      },
+    );
 
-    test('returns null if platform throws error', () async {
-      MockFlutterCrispChatPlatform fakePlatform = MockFlutterCrispChatPlatform();
-      fakePlatform.getSessionIdentifierShouldThrowError = true;
-      FlutterCrispChatPlatform.instance = fakePlatform;
+    test(
+      'returns null if platform throws error',
+      () async {
+        final fakePlatform = MockFlutterCrispChatPlatform();
+        fakePlatform.getSessionIdentifierShouldThrowError = true;
+        FlutterCrispChatPlatform.instance = fakePlatform;
 
-      final sessionId = await FlutterCrispChat.getSessionIdentifier();
-      expect(sessionId, isNull);
-    });
+        final sessionId = await FlutterCrispChat.getSessionIdentifier();
+        expect(sessionId, isNull);
+      },
+    );
   });
 
   group('setSessionSegments', () {
-    test('calls platform method with correct arguments', () {
-      MockFlutterCrispChatPlatform fakePlatform = MockFlutterCrispChatPlatform();
-      FlutterCrispChatPlatform.instance = fakePlatform;
+    test(
+      'calls platform method with correct arguments',
+      () {
+        final fakePlatform = MockFlutterCrispChatPlatform();
+        FlutterCrispChatPlatform.instance = fakePlatform;
 
-      final segments = ['segment1', 'segment2'];
-      FlutterCrispChat.setSessionSegments(segments: segments, overwrite: true);
+        final segments = ['segment1', 'segment2'];
+        FlutterCrispChat.setSessionSegments(
+          segments: segments,
+          overwrite: true,
+        );
 
-      expect(fakePlatform.setSessionSegmentsArgs, equals({'segments': segments, 'overwrite': true}));
-    });
+        expect(
+          fakePlatform.setSessionSegmentsArgs,
+          equals({'segments': segments, 'overwrite': true}),
+        );
+      },
+    );
 
-    test('calls platform method with default overwrite value', () {
-      MockFlutterCrispChatPlatform fakePlatform = MockFlutterCrispChatPlatform();
-      FlutterCrispChatPlatform.instance = fakePlatform;
+    test(
+      'calls platform method with default overwrite value',
+      () {
+        final fakePlatform = MockFlutterCrispChatPlatform();
+        FlutterCrispChatPlatform.instance = fakePlatform;
 
-      final segments = ['segment_a', 'segment_b'];
-      FlutterCrispChat.setSessionSegments(segments: segments); // overwrite is false by default
+        final segments = ['segment_a', 'segment_b'];
+        FlutterCrispChat.setSessionSegments(
+          segments: segments,
+        ); // overwrite is false by default
 
-      expect(fakePlatform.setSessionSegmentsArgs, equals({'segments': segments, 'overwrite': false}));
-    });
+        expect(
+          fakePlatform.setSessionSegmentsArgs,
+          equals({'segments': segments, 'overwrite': false}),
+        );
+      },
+    );
+  });
+
+  group('pushSessionEvent', () {
+    test(
+      'calls platform method with correct arguments',
+      () async {
+        final fakePlatform = MockFlutterCrispChatPlatform();
+        FlutterCrispChatPlatform.instance = fakePlatform;
+
+        await FlutterCrispChat.pushSessionEvent(
+          name: 'testEvent',
+          color: SessionEventColor.red,
+        );
+
+        expect(
+          fakePlatform.setSessionAttributesArgs,
+          equals({'name': 'testEvent', 'color': SessionEventColor.red}),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
This commit introduces tests for the `pushSessionEvent` method in the `FlutterCrispChat` class.

The tests verify that `pushSessionEvent` correctly calls the underlying platform method with the provided event name and color.

The `MockFlutterCrispChatPlatform` has been updated to include a `setSessionAttributesArgs` property to capture the arguments passed to `pushSessionEvent` for verification in the tests.