### PR TITLE
feat: Introduce `pushSessionEvent` and update Dart SDK constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.4.0 - Sunday, 10 August 2025
+
+Added
+---
+* Added new function `pushSessionEvent` to sends a custom event to the Crisp session with `name` and `color`.
+
+Changed
+---
+* Increased the minimum Dart SDK constraint from `>=2.12.0` to `>=2.15.0`.
+
+
 # 2.3.0 - Saturday, 31 May 2025
 
 Added

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ or manually configure pubspec.yml file
 dependencies:
   flutter:
     sdk: flutter
-  crisp_chat: ^2.3.0
+  crisp_chat: ^2.4.0
 ```
 
 ### 2. Setup platform specific settings
@@ -331,22 +331,22 @@ class _CrispChatPageState extends State<CrispChatPage> {
     // Configure Crisp User (Optional)
     // All user fields are optional. Only provide what you have.
     final crispUser = User(
-      email: "user@example.com", // User's email
-      nickName: "John Doe", // User's nickname
-      phone: "1234567890", // User's phone number
-      avatar: "https://example.com/avatar.png", // URL for user's avatar. Must be a valid URL.
+      email: "user@example.com",
+      nickName: "John Doe",
+      phone: "1234567890", 
+      avatar: "https://example.com/avatar.png", 
       company: Company(
-        name: "Example Corp", // Company name
-        url: "https://example.com", // Company website URL. Must be a valid URL.
-        companyDescription: "A sample company providing excellent services.", // Company description
-        employment: Employment(title: "Lead Developer", role: "Software Engineer"), // User's employment details
-        geoLocation: GeoLocation(city: "New York", country: "USA"), // Company's location
+        name: "Example Corp",
+        url: "https://example.com", 
+        companyDescription: "A sample company providing excellent services.",
+        employment: Employment(title: "Lead Developer", role: "Software Engineer"),
+        geoLocation: GeoLocation(city: "New York", country: "USA"),
       ),
     );
 
     // 1. Initialize CrispConfig with all desired parameters.
     _crispConfig = CrispConfig(
-      websiteID: websiteID, // This is the only mandatory field.
+      websiteID: websiteID, // [required] Your Crisp website ID.
       tokenId: "your_user_token_id_optional", // Optional: Assign a unique token to this session.
       sessionSegment: "beta_testers", // Optional: Assign a segment to categorize users (e.g., "premium", "trial").
       user: crispUser, // Optional: Provide user details.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/ios/crisp_chat.podspec
+++ b/ios/crisp_chat.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'crisp_chat'
-  s.version          = '2.3.0'
+  s.version          = '2.4.0'
   s.summary          = 'A flutter plugin package for using crisp chat natively on Android & iOS.'
   s.description      = <<-DESC
   A flutter plugin package for using crisp chat natively on Android & iOS.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: crisp_chat
 description: A flutter plugin package for using crisp chat natively on Android & iOS.
-version: 2.3.0
+version: 2.4.0
 
 readme: README.md
 license: MIT


### PR DESCRIPTION
This commit introduces a new feature and updates project configurations:

**New Feature:**
- Added the `pushSessionEvent` function, allowing users to send custom events with a `name` and `color` to the Crisp session.

**Changes:**
- Updated the `crisp_chat` plugin version from `2.3.0` to `2.4.0` in `README.md`, `example/pubspec.lock`, `pubspec.yaml`, and `ios/crisp_chat.podspec`.
- Increased the minimum Dart SDK constraint from `>=2.12.0` to `>=2.15.0` in `CHANGELOG.md`.
- Minor formatting adjustments in `README.md` for user configuration examples.