### PR TITLE
feat: Update dependencies and support Google Play's 16KB page size requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
-# 2.4.0 - Sunday, 10 August 2025
+# 2.4.1
+
+Added
+---
+* Package now supported Google Play's 16KB page size requirement.
+
+Changed
+---
+* Update Crisp Android SDK `2.0.12` to `2.0.13`.
+* Update AGP from `8.6` to `8.7`.
+* Update Project Level Gradle from `8.4.1` to `8.6.1`.
+* Update `example` project Kotlin from `1.7.10` to `2.1.0`.
+
+
+# 2.4.0
 
 Added
 ---
@@ -9,7 +23,7 @@ Changed
 * Increased the minimum Dart SDK constraint from `>=2.12.0` to `>=2.15.0`.
 
 
-# 2.3.0 - Saturday, 31 May 2025
+# 2.3.0
 
 Added
 ---

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ or manually configure pubspec.yml file
 dependencies:
   flutter:
     sdk: flutter
-  crisp_chat: ^2.4.0
+  crisp_chat: ^2.4.1
 ```
 
 ### 2. Setup platform specific settings

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.4.1"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/ios/crisp_chat.podspec
+++ b/ios/crisp_chat.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'crisp_chat'
-  s.version          = '2.4.0'
+  s.version          = '2.4.1'
   s.summary          = 'A flutter plugin package for using crisp chat natively on Android & iOS.'
   s.description      = <<-DESC
   A flutter plugin package for using crisp chat natively on Android & iOS.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: crisp_chat
 description: A flutter plugin package for using crisp chat natively on Android & iOS.
-version: 2.4.0
+version: 2.4.1
 
 readme: README.md
 license: MIT


### PR DESCRIPTION


**Added:**
- Package now supports Google Play's 16KB page size requirement.

**Changed:**
- Updated Crisp Android SDK from `2.0.12` to `2.0.13`.
- Updated Android Gradle Plugin (AGP) from `8.6` to `8.7`.
- Updated Project Level Gradle from `8.4.1` to `8.6.1`.
- Updated Kotlin version in the `example` project from `1.7.10` to `2.1.0`.
- Incremented `crisp_chat` plugin version from `2.4.0` to `2.4.1` in `README.md`, `example/pubspec.lock`, `pubspec.yaml`, and `ios/crisp_chat.podspec`.