### PR TITLE
Release/v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
-# 2.4.0 - Sunday, 10 August 2025
+# 2.4.1
+
+Added
+---
+* Package now supported Google Play's 16KB page size requirement.
+
+Changed
+---
+* Update Crisp Android SDK `2.0.12` to `2.0.13`.
+* Update AGP from `8.6` to `8.7`.
+* Update Project Level Gradle from `8.4.1` to `8.6.1`.
+* Update `example` project Kotlin from `1.7.10` to `2.1.0`.
+
+
+# 2.4.0
 
 Added
 ---
@@ -9,7 +23,7 @@ Changed
 * Increased the minimum Dart SDK constraint from `>=2.12.0` to `>=2.15.0`.
 
 
-# 2.3.0 - Saturday, 31 May 2025
+# 2.3.0
 
 Added
 ---

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ or manually configure pubspec.yml file
 dependencies:
   flutter:
     sdk: flutter
-  crisp_chat: ^2.4.0
+  crisp_chat: ^2.4.1
 ```
 
 ### 2. Setup platform specific settings

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.4.0'
+        classpath 'com.android.tools.build:gradle:8.6.1'
     }
 }
 
@@ -38,5 +38,5 @@ android {
 
 dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'im.crisp:crisp-sdk:2.0.12'
+    implementation 'im.crisp:crisp-sdk:2.0.13'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -42,7 +42,7 @@ android {
         applicationId "com.alaminkarno.flutter_crisp_chat_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -19,11 +19,11 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.3.0" apply false
+    id "com.android.application" version "8.6.1" apply false
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.3.15" apply false
     // END: FlutterFire Configuration
-    id "org.jetbrains.kotlin.android" version "1.8.10" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.4.1"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/ios/Classes/SwiftFlutterCrispChatPlugin.swift
+++ b/ios/Classes/SwiftFlutterCrispChatPlugin.swift
@@ -146,7 +146,7 @@ public class SwiftFlutterCrispChatPlugin: NSObject, FlutterPlugin, UIApplication
                     eventColor = .blue
                 }
             }
-            
+
             let event = SessionEvent(name: name, color: eventColor)
             CrispSDK.session.pushEvents([event])
             result(nil)

--- a/ios/crisp_chat.podspec
+++ b/ios/crisp_chat.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'crisp_chat'
-  s.version          = '2.4.0'
+  s.version          = '2.4.1'
   s.summary          = 'A flutter plugin package for using crisp chat natively on Android & iOS.'
   s.description      = <<-DESC
   A flutter plugin package for using crisp chat natively on Android & iOS.

--- a/lib/src/flutter_crisp_chat_method_channel.dart
+++ b/lib/src/flutter_crisp_chat_method_channel.dart
@@ -85,9 +85,4 @@ class MethodChannelFlutterCrispChat extends FlutterCrispChatPlatform {
       'color': color.name.toString(),
     });
   }
-
-  @override
-  Future<void> pushSessionEvent(Map<String, dynamic> event) async {
-    await methodChannel.invokeMethod('pushSessionEvent', event);
-  }
 }

--- a/lib/src/flutter_crisp_chat_method_channel.dart
+++ b/lib/src/flutter_crisp_chat_method_channel.dart
@@ -85,4 +85,9 @@ class MethodChannelFlutterCrispChat extends FlutterCrispChatPlatform {
       'color': color.name.toString(),
     });
   }
+
+  @override
+  Future<void> pushSessionEvent(Map<String, dynamic> event) async {
+    await methodChannel.invokeMethod('pushSessionEvent', event);
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: crisp_chat
 description: A flutter plugin package for using crisp chat natively on Android & iOS.
-version: 2.4.0
+version: 2.4.1
 
 readme: README.md
 license: MIT


### PR DESCRIPTION
Added
---
* Package now supported Google Play's 16KB page size requirement.

Changed
---
* Update Crisp Android SDK `2.0.12` to `2.0.13`.
* Update AGP from `8.6` to `8.7`.
* Update Project Level Gradle from `8.4.1` to `8.6.1`.
* Update `example` project Kotlin from `1.7.10` to `2.1.0`.