### PR TITLE
chore: Update GitHub Actions workflow for deploying docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,8 +2,6 @@
 name: Deploy VitePress Docs to GitHub Pages
 
 # Controls when the action will run.
-# This workflow runs on pushes to the 'main' branch, but only if files inside 'docsrc/' have changed.
-# It also allows you to run it manually from the Actions tab in your GitHub repository.
 on:
   push:
     branches:
@@ -12,52 +10,68 @@ on:
       - 'docsrc/**'
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel.
-jobs:
-  # This job is named "build-and-deploy"
-  build-and-deploy:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+# Grant GITHUB_TOKEN the permissions required to deploy to GitHub Pages
+permissions:
+  contents: read
+  pages: write      # to deploy to Pages
+  id-token: write   # to verify the deployment originates from an authentic source
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
     steps:
-      # 1. Checks out your repository under $GITHUB_WORKSPACE, so the job can access it
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # VitePress uses git history to show "last updated" info. Fetch all history.
-          fetch-depth: 0
+          fetch-depth: 0 # Needed for VitePress to get git commit history for "last updated"
 
-      # 2. Sets up Node.js in the runner environment
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18' # Use a Long-Term Support (LTS) version of Node.js
-          cache: 'npm' # Cache npm dependencies for faster builds
-          cache-dependency-path: 'docsrc/package.json' # Or package.json if you don't use a lock file
+          node-version: '18' # Or a newer LTS version
+          cache: 'npm'
+          cache-dependency-path: 'docsrc/package-lock.json'
 
-      # 3. Install dependencies and build the static site
-      - name: Build VitePress site
+      - name: Install dependencies and build site
         run: |
-          cd docsrc # Navigate into the directory with package.json
+          cd docsrc
           npm install
-          npm run build # This command runs `vitepress build docs`
+          npm run build # This builds the site to docsrc/docs/.vitepress/dist
 
-      # 4. Deploy the built site to GitHub Pages
-      - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          # The folder where the built site is located, relative to the repository root
-          folder: docsrc/docs/.vitepress/dist
+          # This is the path to the directory where your VitePress site was built
+          path: 'docsrc/docs/.vitepress/dist'
 
-    # Grant permissions for the GITHUB_TOKEN to upload to GitHub Pages
+  # Deployment job
+  deploy:
+    # Add a dependency to the build job
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to deploy to GitHub Pages
     permissions:
-      contents: read
-      pages: write
-      id-token: write
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an authentic source
 
-    # Configure the deployment environment
+    # Deploy to the github-pages environment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This commit refactors the `deploy-docs.yml` GitHub Actions workflow to improve its structure and security for deploying VitePress documentation to GitHub Pages.

**Changed:**
- Split the single `build-and-deploy` job into separate `build` and `deploy` jobs for better separation of concerns.
- Updated the workflow to use `actions/configure-pages@v4` and `actions/upload-pages-artifact@v3` for a more modern deployment process.
- Explicitly defined permissions at the top level and for each job (`pages: write`, `id-token: write`) to follow the principle of least privilege.
- Added a `concurrency` group to prevent multiple simultaneous deployments.
- Updated the Node.js setup to cache dependencies based on `package-lock.json`.
- Refined comments and step names for improved clarity and maintainability.