### PR TITLE
feat: Upgrade Crisp Android SDK to 2.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 
+# [Unreleased]
+
+Changed
+---
+* Upgraded Crisp Android SDK from `2.0.16` to `2.0.17`.
+  - Scroll to last message after visitor sent it
+  - Updated smileys sorting according to Web dashboard
+
 # 2.4.4
 
 Added

--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ Before using your development token, you now need to associate your marketplace 
 ## Supported SDK Versions
 This plugin aims to stay compatible with the latest versions of the native Crisp SDKs. As of the latest update, it has been tested with:
 
-- Crisp Android SDK version: `2.0.16`
+- Crisp Android SDK version: `2.0.17`
 - Crisp iOS SDK version: ~> `2.13.0`
 
 While the plugin may work with other versions, using versions close to these is recommended for optimal compatibility. Please refer to the official Crisp SDK documentation for the most current native SDK details.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,6 @@ android {
 
 dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'im.crisp:crisp-sdk:2.0.16'
+    implementation 'im.crisp:crisp-sdk:2.0.17'
     compileOnly 'com.google.firebase:firebase-messaging:24.1.0'
 }

--- a/docsrc/docs/reference/changelog.md
+++ b/docsrc/docs/reference/changelog.md
@@ -19,6 +19,13 @@ next: false
 
 All notable changes to the `crisp_chat` package are documented here. For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/alamin-karno/flutter-crisp-chat/blob/main/CHANGELOG.md).
 
+## [Unreleased]
+
+### Changed
+- Upgraded Crisp Android SDK from `2.0.16` to `2.0.17`
+  - Scroll to last message after visitor sent it
+  - Updated smileys sorting according to Web dashboard
+
 ## 2.4.4
 
 ### Added

--- a/docsrc/docs/reference/faq.md
+++ b/docsrc/docs/reference/faq.md
@@ -23,7 +23,7 @@ next:
 
 ### What platforms does this plugin support?
 
-Android and iOS. The plugin wraps the official Crisp Android SDK (`2.0.16`) and Crisp iOS SDK (`~> 2.13.0`).
+Android and iOS. The plugin wraps the official Crisp Android SDK (`2.0.17`) and Crisp iOS SDK (`~> 2.13.0`).
 
 ### What is the minimum Flutter version required?
 


### PR DESCRIPTION
This commit upgrades the native Crisp Android SDK from version `2.0.16` to `2.0.17`.

**Key changes from the native SDK update:**
- Implements scrolling to the last message after a visitor sends it.
- Updates the sorting of smileys to match the Web dashboard.

**Other changes:**
- Updated the SDK version number in `README.md` and `faq.md`.
- Added release notes for this change to `CHANGELOG.md` and the documentation changelog.