### PR TITLE
release/v2.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-# [Unreleased]
+# [2.4.5]
 
 Changed
 ---

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ or manually configure pubspec.yml file
 dependencies:
   flutter:
     sdk: flutter
-  crisp_chat: ^2.4.4
+  crisp_chat: ^2.4.5
 ```
 
 ### 2. Setup platform specific settings

--- a/docsrc/docs/community/author.md
+++ b/docsrc/docs/community/author.md
@@ -44,11 +44,11 @@ Al-Amin is an active open source contributor. The Flutter Crisp Chat plugin is o
 
 ### Flutter Crisp Chat Stats
 
-- **First published:** 2022
-- **Current version:** 2.4.4
+- **First published:** 2023
+- **Current version:** 2.4.5
 - **Platform:** pub.dev ([crisp_chat](https://pub.dev/packages/crisp_chat))
 - **License:** MIT
-- **Native SDKs:** Crisp Android SDK `2.0.16` · Crisp iOS SDK `~> 2.13.0`
+- **Native SDKs:** Crisp Android SDK `2.0.17` · Crisp iOS SDK `~> 2.13.0`
 
 ## Support My Work
 

--- a/docsrc/docs/getting_started/install.md
+++ b/docsrc/docs/getting_started/install.md
@@ -31,7 +31,7 @@ Or manually add it to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  crisp_chat: ^2.4.4
+  crisp_chat: ^2.4.5
 ```
 
 Then run:

--- a/docsrc/docs/index.md
+++ b/docsrc/docs/index.md
@@ -12,6 +12,10 @@ head:
     - name: keywords
       content: "flutter crisp chat, crisp chat flutter, crisp sdk flutter, flutter live chat, flutter customer support, crisp chat plugin, crisp_chat pub.dev, flutter chat widget"
 
+  - - meta
+    - name: google-site-verification
+      content: gjJvl6jAwo8pORAiWoawGoaLl9DNNyoA9Mo73_M7AQY
+
 hero:
   name: Flutter Crisp Chat
   text: Native Crisp Live Chat for Flutter

--- a/docsrc/docs/reference/changelog.md
+++ b/docsrc/docs/reference/changelog.md
@@ -19,7 +19,7 @@ next: false
 
 All notable changes to the `crisp_chat` package are documented here. For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/alamin-karno/flutter-crisp-chat/blob/main/CHANGELOG.md).
 
-## [Unreleased]
+## [2.4.5]
 
 ### Changed
 - Upgraded Crisp Android SDK from `2.0.16` to `2.0.17`

--- a/ios/crisp_chat.podspec
+++ b/ios/crisp_chat.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'crisp_chat'
-  s.version          = '2.4.4'
+  s.version          = '2.4.5'
   s.summary          = 'Flutter plugin for Crisp Chat'
   s.description      = 'A Flutter plugin for Crisp Chat SDK on iOS.'
   s.homepage         = 'https://github.com/alamin-karno/flutter-crisp-chat'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: crisp_chat
 description: A flutter plugin package for using crisp chat natively on Android & iOS.
-version: 2.4.4
+version: 2.4.5
 
 readme: README.md
 license: MIT


### PR DESCRIPTION
This commit prepares for the `2.4.5` release by updating the version number across multiple files and documenting the changes.

- Bumps the package version from `2.4.4` to `2.4.5` in `pubspec.yaml`, `README.md`, the iOS `podspec`, and various documentation files.
- Upgrades the native Crisp Android SDK from `2.0.16` to `2.0.17`.
- Updates `CHANGELOG.md` and the documentation changelog to reflect the new version and its changes.
- Corrects the "First published" year in the author documentation from 2022 to 2023.