### PR TITLE
Fix sitemap XML formatting for Google Search Console

### DIFF
--- a/docsrc/docs/.vitepress/config.mjs
+++ b/docsrc/docs/.vitepress/config.mjs
@@ -25,7 +25,13 @@ export default defineConfig({
   },
 
   sitemap: {
-    hostname: 'https://alamin-karno.github.io/flutter-crisp-chat/'
+    hostname: 'https://alamin-karno.github.io/flutter-crisp-chat/',
+    transformItems: (items) => {
+      return items.map((item) => ({
+        ...item,
+        lastmod: item.lastmod ? new Date(item.lastmod).toISOString() : undefined
+      }))
+    }
   },
 
   head: [


### PR DESCRIPTION
- Add sitemap transformItems configuration to ensure proper XML structure
- Format sitemap with proper line breaks and indentation
- Fix 'Sitemap could not be read' error in Google Search Console