### PR TITLE
chore: upgrade Crisp Android SDK to 2.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Added
 * Added `ModalPresentationStyle` enum with options: `fullScreen`, `pageSheet`, `formSheet`, `overFullScreen`, `overCurrentContext`, and `popover`.
 * Default modal presentation style is set to `fullScreen` to prevent touch events from passing through to the underlying Flutter UI.
 
+Changed
+---
+* Upgraded Crisp Android SDK from `2.0.17` to `2.0.18`.
+  - Fixed crash on message deserialization when origin is null.
+
 Fixed
 ---
 * Fixed issue where `enableNotifications: false` in `CrispConfig` was being ignored on iOS, causing the Crisp SDK to still prompt for push notification permissions after sending the first message.

--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ Before using your development token, you now need to associate your marketplace 
 ## Supported SDK Versions
 This plugin aims to stay compatible with the latest versions of the native Crisp SDKs. As of the latest update, it has been tested with:
 
-- Crisp Android SDK version: `2.0.17`
+- Crisp Android SDK version: `2.0.18`
 - Crisp iOS SDK version: ~> `2.13.0`
 
 While the plugin may work with other versions, using versions close to these is recommended for optimal compatibility. Please refer to the official Crisp SDK documentation for the most current native SDK details.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,6 @@ android {
 
 dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'im.crisp:crisp-sdk:2.0.17'
+    implementation 'im.crisp:crisp-sdk:2.0.18'
     compileOnly 'com.google.firebase:firebase-messaging:24.1.0'
 }

--- a/docsrc/docs/community/author.md
+++ b/docsrc/docs/community/author.md
@@ -48,7 +48,7 @@ Al-Amin is an active open source contributor. The Flutter Crisp Chat plugin is o
 - **Current version:** 2.4.5
 - **Platform:** pub.dev ([crisp_chat](https://pub.dev/packages/crisp_chat))
 - **License:** MIT
-- **Native SDKs:** Crisp Android SDK `2.0.17` · Crisp iOS SDK `~> 2.13.0`
+- **Native SDKs:** Crisp Android SDK `2.0.18` · Crisp iOS SDK `~> 2.13.0`
 
 ## Support My Work
 

--- a/docsrc/docs/getting_started/overview.md
+++ b/docsrc/docs/getting_started/overview.md
@@ -25,31 +25,31 @@ next:
 
 ## What This Plugin Provides
 
-| Feature | Description |
-|---|---|
-| **Open Chat** | Launch the native Crisp chat UI with one method call |
-| **User Identification** | Set user email, name, phone, avatar, and company details |
-| **Push Notifications** | Full FCM (Android) and APNs (iOS) support with two handling modes |
-| **Session Management** | Set custom session data, segments, and events |
-| **Unread Messages** | Query unread message count via the Crisp REST API |
-| **Session Control** | Get session identifiers and reset sessions on logout |
+| Feature                 | Description                                                       |
+|-------------------------|-------------------------------------------------------------------|
+| **Open Chat**           | Launch the native Crisp chat UI with one method call              |
+| **User Identification** | Set user email, name, phone, avatar, and company details          |
+| **Push Notifications**  | Full FCM (Android) and APNs (iOS) support with two handling modes |
+| **Session Management**  | Set custom session data, segments, and events                     |
+| **Unread Messages**     | Query unread message count via the Crisp REST API                 |
+| **Session Control**     | Get session identifiers and reset sessions on logout              |
 
 ## Supported SDK Versions
 
-| Platform | SDK | Version |
-|---|---|---|
-| Android | Crisp Android SDK | `2.0.16` |
-| iOS | Crisp iOS SDK | `~> 2.13.0` |
+| Platform | SDK               | Version     |
+|----------|-------------------|-------------|
+| Android  | Crisp Android SDK | `2.0.18`    |
+| iOS      | Crisp iOS SDK     | `~> 2.13.0` |
 
 ## Requirements
 
-| Platform | Minimum Version |
-|---|---|
-| Flutter | 3.0+ |
-| Dart | 2.15.0+ |
-| Android | API 23 (Android 6.0) |
-| iOS | 13.0+ |
-| compileSdkVersion | 36 |
+| Platform          | Minimum Version      |
+|-------------------|----------------------|
+| Flutter           | 3.0+                 |
+| Dart              | 2.15.0+              |
+| Android           | API 23 (Android 6.0) |
+| iOS               | 13.0+                |
+| compileSdkVersion | 36                   |
 
 ## Quick Links
 

--- a/docsrc/docs/reference/changelog.md
+++ b/docsrc/docs/reference/changelog.md
@@ -26,6 +26,10 @@ All notable changes to the `crisp_chat` package are documented here. For the ful
 - `ModalPresentationStyle` enum with options: `fullScreen`, `pageSheet`, `formSheet`, `overFullScreen`, `overCurrentContext`, and `popover`
 - Default modal presentation style is set to `fullScreen` to prevent touch events from passing through to the underlying Flutter UI
 
+### Changed
+- Upgraded Crisp Android SDK from `2.0.17` to `2.0.18`
+  - Fixed crash on message deserialization when origin is null
+
 ### Fixed
 - Fixed issue where `enableNotifications: false` in `CrispConfig` was being ignored on iOS, causing the Crisp SDK to still prompt for push notification permissions after sending the first message
 

--- a/docsrc/docs/reference/faq.md
+++ b/docsrc/docs/reference/faq.md
@@ -23,7 +23,7 @@ next:
 
 ### What platforms does this plugin support?
 
-Android and iOS. The plugin wraps the official Crisp Android SDK (`2.0.17`) and Crisp iOS SDK (`~> 2.13.0`).
+Android and iOS. The plugin wraps the official Crisp Android SDK (`2.0.18`) and Crisp iOS SDK (`~> 2.13.0`).
 
 ### What is the minimum Flutter version required?
 


### PR DESCRIPTION
- Update Crisp Android SDK version from `2.0.17` to `2.0.18` in `android/build.gradle`
- Fix crash on message deserialization when origin is null (via SDK upgrade)
- Update version references across documentation: `README.md`, `CHANGELOG.md`, `overview.md`, `author.md`, `changelog.md`, and `faq.md`