### PR TITLE
Update Node.js version and documentation metadata

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18' # Or a newer LTS version
+          node-version: '20' # Updated to meet VitePress 2.x requirements (^20.19.0 || >=22.12.0)
           cache: 'npm'
           cache-dependency-path: 'docsrc/package-lock.json'
 

--- a/docsrc/docs/.vitepress/theme/data/blogs.json
+++ b/docsrc/docs/.vitepress/theme/data/blogs.json
@@ -23,7 +23,7 @@
       "readTime": "4 min read"
     },
     {
-      "id": "how-a-bug-report-led-me-to-give-flutter-developers-full-control-of-crisp-chat-modals-on-ios",
+      "id": "full-control-of-crisp-chat-modals-on-ios",
       "title": "How a Bug Report Led Me to Give Flutter Developers Full Control of Crisp Chat Modals on iOS",
       "description": "One of the things I enjoy most about maintaining open-source software is that sometimes the best improvements start with something very small.",
       "url": "https://medium.com/@alaminkarno/how-a-bug-report-led-me-to-give-flutter-developers-full-control-of-crisp-chat-modals-on-ios-da13fa0fa2db",

--- a/docsrc/package.json
+++ b/docsrc/package.json
@@ -11,6 +11,9 @@
   },
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "devDependencies": {
     "vitepress": "2.0.0-alpha.17",
     "vue": "^3.5.0"


### PR DESCRIPTION
- Update Node.js to version 20 in `deploy-docs.yml` to meet VitePress 2.x requirements
- Add Node.js engine constraints to `docsrc/package.json`
- Shorten the blog post ID for the iOS Crisp Chat modals article in `blogs.json`