### PR TITLE
Add sponsorship info

### DIFF
--- a/docsrc/docs/.vitepress/theme/data/sponsor.json
+++ b/docsrc/docs/.vitepress/theme/data/sponsor.json
@@ -1,4 +1,10 @@
 {
-    "platinum": [],
+    "platinum": [
+      {
+        "name": "Crisp",
+        "image": "https://uploads-ssl.webflow.com/5fcdef3cc7cf1d1e14b4ba0c/5fef34e1b64093d0aec1d091_crisp-chat.png",
+        "link": "https://crisp.chat/"
+      }
+    ],
     "average": []
 }


### PR DESCRIPTION
- Update `sponsor.json` to include Crisp in the platinum tier with its logo and website link