### PR TITLE
Add markMessagesAsRead and document iOS unread count limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,11 @@ final formSheetConfig = CrispConfig(
 
 **Note:** This parameter is iOS-specific and will only affect iOS devices. On Android, the chat will always use the platform's default presentation behavior.
 
-For every request that you make to `getUnreadMessageCount`, you must submit your authentication token (`identifier` and `key`), as well as your `website_id`. 
+For every request that you make to `getUnreadMessageCount` or `markMessagesAsRead`, you must submit your authentication token (`identifier` and `key`), as well as your `website_id`.
+
+::: tip iOS unread count
+On iOS, `unread.visitor` may not reset after reading chat in the native SDK. Call `FlutterCrispChat.markMessagesAsRead()` after the visitor closes chat. See [docs/unread-count-verification.md](docs/unread-count-verification.md).
+:::
 
 **Obtaining `Identifier` & `Key`:**
 

--- a/docs/crisp-sdk-ios-unread-issue.md
+++ b/docs/crisp-sdk-ios-unread-issue.md
@@ -1,0 +1,75 @@
+# Crisp iOS SDK Issue — Unread Count Not Clearing
+
+Use this document to file an issue on the official Crisp iOS SDK repository:
+
+**Create issue:** https://github.com/crisp-im/crisp-sdk-ios/issues/new
+
+---
+
+## Title
+
+iOS SDK does not reset `unread.visitor` after visitor reads operator messages in ChatViewController
+
+## Description
+
+### Environment
+
+- **SDK:** Crisp iOS `>= 2.13.0` (via [flutter-crisp-chat](https://github.com/alamin-karno/flutter-crisp-chat) plugin)
+- **Devices:** iPhone 16e, iPhone 15 Pro Max
+- **OS:** iOS 26.2
+- **Flutter:** 3.41.9
+
+### Steps to reproduce
+
+1. Start a Crisp session and receive operator messages so `unread.visitor > 0`.
+2. Confirm via REST API:
+   ```
+   GET /v1/website/{website_id}/conversation/{session_id}
+   ```
+   Response includes `"unread": { "operator": 0, "visitor": N }` where `N > 0`.
+3. Open chat with `ChatViewController` (presented from Flutter via `CrispSDK`).
+4. Scroll through and read all operator messages.
+5. Dismiss/close the chat UI.
+6. Wait 5–10 seconds.
+7. Repeat the same GET request.
+
+### Actual behavior
+
+`unread.visitor` remains unchanged (e.g. still `6`) after the visitor has read all operator messages in the native iOS chat UI.
+
+The same stale value is returned by `GET /v1/website/{website_id}/conversation/{session_id}` — this is server-side state, not a client parsing issue.
+
+### Expected behavior
+
+After the visitor reads all operator messages in the chat UI, `unread.visitor` should be `0` — matching Web Chatbox SDK behavior where read receipts are sent automatically.
+
+### Control test (REST mark-as-read works)
+
+Manually calling the REST API clears the count:
+
+```bash
+PATCH /v1/website/{website_id}/conversation/{session_id}/read
+Content-Type: application/json
+
+{"from": "operator", "origin": "chat"}
+```
+
+After this PATCH (HTTP 202), a subsequent GET shows `unread.visitor: 0`.
+
+This proves:
+- The REST unread counter is correct and updatable.
+- The iOS SDK is not sending read receipts to the backend when the visitor views messages.
+
+### Question for Crisp team
+
+Should the iOS SDK automatically send read receipts (like the Web SDK) when a visitor views operator messages? If yes, this appears to be an iOS SDK bug. If no, please document that `unread.visitor` is not reliable for mobile badge counts and recommend local tracking or explicit REST mark-as-read.
+
+### References
+
+- [Get a Conversation](https://docs.crisp.chat/references/rest-api/v1/#get-a-conversation) — `unread.visitor` field
+- [Mark Messages As Read In Conversation](https://docs.crisp.chat/references/rest-api/v1/#mark-messages-as-read-in-conversation)
+- [iOS SDK guide](https://docs.crisp.chat/guides/chatbox-sdks/ios-sdk/) — no unread/read APIs documented
+
+### Verification script
+
+See `scripts/verify_unread_read_receipts.sh` in the flutter-crisp-chat repository for automated REST verification.

--- a/docs/ios-unread-workaround-decision.md
+++ b/docs/ios-unread-workaround-decision.md
@@ -1,0 +1,52 @@
+# Workaround Decision: iOS Unread Count
+
+**Date:** 2026-05-31  
+**Status:** Adopted pending Crisp iOS SDK fix
+
+## Problem
+
+`getUnreadMessageCount()` reads server-side `unread.visitor` from the Crisp REST API. On iOS, the native Crisp SDK does not appear to send read receipts when a visitor reads operator messages, so the count stays non-zero after closing chat.
+
+## Decision
+
+Until Crisp fixes the iOS SDK, this plugin adopts:
+
+1. **Document the limitation** — troubleshooting and unread messages docs explain the iOS behavior and link to upstream issue template.
+2. **Provide `markMessagesAsRead()`** — apps call this after the visitor closes chat to reset `unread.visitor` via REST `PATCH /read`.
+3. **Verification script** — `scripts/verify_unread_read_receipts.sh` for REST control tests (GET → PATCH → GET).
+4. **Upstream issue** — report to [crisp-im/crisp-sdk-ios](https://github.com/crisp-im/crisp-sdk-ios) using [crisp-sdk-ios-unread-issue.md](./crisp-sdk-ios-unread-issue.md).
+
+## Not chosen (for now)
+
+| Option                          | Reason deferred                                                                                                                   |
+|---------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| Auto mark-as-read on chat close | Requires native `onChatClosed` callback on iOS; assumes all opened chats mean "read all"; can be added later behind a config flag |
+| Local badge tracking only       | iOS SDK exposes no message/chat events in this plugin; Android has `EventsCallback` but cross-platform inconsistency              |
+| Docs only                       | `markMessagesAsRead()` is low-risk and gives apps an immediate fix                                                                |
+
+## Recommended app integration
+
+```dart
+Future<void> openChatAndClearUnread({
+  required CrispConfig config,
+  required String websiteId,
+  required String identifier,
+  required String key,
+}) async {
+  await FlutterCrispChat.openCrispChat(config: config);
+
+  // After user closes chat (poll session or use your own UX hook):
+  await FlutterCrispChat.markMessagesAsRead(
+    websiteId: websiteId,
+    identifier: identifier,
+    key: key,
+  );
+}
+```
+
+On Android, verify whether REST `unread.visitor` clears without `markMessagesAsRead`. If it does, call `markMessagesAsRead` only on iOS (`defaultTargetPlatform == TargetPlatform.iOS`).
+
+## Revisit when
+
+- Crisp confirms and ships iOS SDK read-receipt fix → remove workaround docs emphasis, keep `markMessagesAsRead` as optional API.
+- Crisp confirms mobile SDKs never sync REST unread → document permanently; consider local tracking via Android `EventsCallback` + iOS when SDK adds events.

--- a/docs/unread-count-verification.md
+++ b/docs/unread-count-verification.md
@@ -1,0 +1,79 @@
+# Unread Count Verification Guide
+
+This guide supports the iOS unread count root-cause analysis. Run these steps with your Crisp Marketplace REST credentials.
+
+## Prerequisites
+
+- Crisp Marketplace plugin token (`identifier` + `key`)
+- Website ID and an active session ID (`FlutterCrispChat.getSessionIdentifier()`)
+- Operator messages in the conversation so `unread.visitor > 0`
+
+## Automated REST verification
+
+```bash
+export CRISP_WEBSITE_ID="your-website-id"
+export CRISP_IDENTIFIER="your-plugin-identifier"
+export CRISP_KEY="your-plugin-key"
+export CRISP_SESSION_ID="session_..."
+
+chmod +x scripts/verify_unread_read_receipts.sh
+
+# Current server unread counters
+./scripts/verify_unread_read_receipts.sh get
+
+# Control test: PATCH /read then GET again
+./scripts/verify_unread_read_receipts.sh full
+```
+
+### Expected results
+
+| Step                                            | Expected if iOS SDK bug    | Meaning                                             |
+|-------------------------------------------------|----------------------------|-----------------------------------------------------|
+| GET before reading chat                         | `unread.visitor > 0`       | Server has unread operator messages                 |
+| Read all messages in iOS chat, close, GET again | `unread.visitor` unchanged | iOS SDK did not send read receipts                  |
+| `full` script after PATCH /read                 | `unread.visitor = 0`       | REST mark-as-read works; plugin workaround is valid |
+
+Record your results:
+
+```
+Platform: iOS / Android
+Device:
+SDK version:
+GET before chat: unread.visitor =
+GET after reading in native chat: unread.visitor =
+GET after PATCH /read: unread.visitor =
+```
+
+## iOS manual test
+
+1. Receive operator messages (push or while app open).
+2. `./scripts/verify_unread_read_receipts.sh get` — note `unread.visitor`.
+3. Open chat via `FlutterCrispChat.openCrispChat()`, read all messages, close chat.
+4. Wait 10 seconds.
+5. `./scripts/verify_unread_read_receipts.sh get` — compare with step 2.
+6. `./scripts/verify_unread_read_receipts.sh mark-read` — confirm PATCH clears count.
+
+## Android comparison test
+
+Repeat the same steps on Android with the **same session** (same `CRISP_SESSION_ID`):
+
+1. GET unread before opening `ChatActivity`.
+2. Open chat, read all messages, close.
+3. GET unread after close.
+
+If Android shows `unread.visitor = 0` after step 3 but iOS does not, the bug is **iOS-specific**. File on [crisp-im/crisp-sdk-ios](https://github.com/crisp-im/crisp-sdk-ios).
+
+If both platforms keep `unread.visitor > 0`, mobile SDKs may not sync read receipts in general — use `FlutterCrispChat.markMessagesAsRead()` after chat close.
+
+## File upstream issue
+
+```bash
+./scripts/file-crisp-ios-unread-issue.sh
+```
+
+Or paste [crisp-sdk-ios-unread-issue.md](./crisp-sdk-ios-unread-issue.md) at:
+https://github.com/crisp-im/crisp-sdk-ios/issues/new
+
+## Plugin workaround
+
+See [ios-unread-workaround-decision.md](./ios-unread-workaround-decision.md).

--- a/docsrc/docs/core_feature/unread_messages.md
+++ b/docsrc/docs/core_feature/unread_messages.md
@@ -125,6 +125,57 @@ Internally, `getUnreadMessageCount` does the following:
 
 If there is no active session (e.g., the user hasn't opened the chat yet), the method returns `null`.
 
+## iOS limitation: unread count not clearing after reading chat
+
+On iOS, the native Crisp SDK may **not send read receipts** to the Crisp backend when a visitor reads operator messages in `ChatViewController`. The REST field `unread.visitor` therefore stays non-zero even after the chat is closed — this is a **Crisp iOS SDK limitation**, not a bug in this plugin's REST call.
+
+### Workaround: mark messages as read via REST
+
+After the visitor closes the chat, call [markMessagesAsRead](#markmessagesasread) to reset the server-side counter:
+
+```dart
+await FlutterCrispChat.markMessagesAsRead(
+  websiteId: 'YOUR_WEBSITE_ID',
+  identifier: 'YOUR_IDENTIFIER',
+  key: 'YOUR_KEY',
+);
+
+final count = await FlutterCrispChat.getUnreadMessageCount(
+  websiteId: 'YOUR_WEBSITE_ID',
+  identifier: 'YOUR_IDENTIFIER',
+  key: 'YOUR_KEY',
+);
+// count should now be 0
+```
+
+### Verify with REST (control test)
+
+Use the verification script with your Marketplace credentials:
+
+```bash
+export CRISP_WEBSITE_ID=... CRISP_IDENTIFIER=... CRISP_KEY=... CRISP_SESSION_ID=...
+./scripts/verify_unread_read_receipts.sh full
+```
+
+If `PATCH /read` clears `unread.visitor` but reading in the iOS chat does not, file an issue with Crisp using [docs/crisp-sdk-ios-unread-issue.md](https://github.com/alamin-karno/flutter-crisp-chat/blob/main/docs/crisp-sdk-ios-unread-issue.md).
+
+See also [Platform-Specific Issues — iOS unread count](/troubleshooting/platform_specific#ios-unread-count-not-clearing).
+
+## markMessagesAsRead
+
+Marks all operator messages as read for the current session via the Crisp REST API. Use on iOS when [getUnreadMessageCount](#usage) stays non-zero after the visitor reads chat.
+
+```dart
+final success = await FlutterCrispChat.markMessagesAsRead(
+  websiteId: 'YOUR_WEBSITE_ID',
+  identifier: 'YOUR_IDENTIFIER',
+  key: 'YOUR_KEY',
+);
+// success == true when accepted (HTTP 202)
+```
+
+**Returns:** `true` on success, `false` on API error, `null` if no active session.
+
 ## Next Steps
 
 - [Firebase Setup](/notifications/firebase_setup) — Set up push notifications for your app

--- a/docsrc/docs/reference/api_documentation.md
+++ b/docsrc/docs/reference/api_documentation.md
@@ -39,9 +39,9 @@ Opens the native Crisp chat UI.
 static Future<void> openCrispChat({required CrispConfig config})
 ```
 
-| Parameter | Type | Required | Description |
-|---|---|---|---|
-| `config` | `CrispConfig` | Yes | Configuration object with website ID, user details, etc. |
+| Parameter | Type          | Required | Description                                              |
+|-----------|---------------|----------|----------------------------------------------------------|
+| `config`  | `CrispConfig` | Yes      | Configuration object with website ID, user details, etc. |
 
 **Throws:**
 - `ArgumentError` if `config.user.email` is provided but invalid
@@ -71,10 +71,10 @@ Sets a custom string value in the current session.
 static void setSessionString({required String key, required String value})
 ```
 
-| Parameter | Type | Required | Description |
-|---|---|---|---|
-| `key` | `String` | Yes | Data key (must not be empty) |
-| `value` | `String` | Yes | String value (must not be empty) |
+| Parameter | Type     | Required | Description                      |
+|-----------|----------|----------|----------------------------------|
+| `key`     | `String` | Yes      | Data key (must not be empty)     |
+| `value`   | `String` | Yes      | String value (must not be empty) |
 
 **Throws:** `ArgumentError` if `key` or `value` is empty.
 
@@ -88,10 +88,10 @@ Sets a custom integer value in the current session.
 static void setSessionInt({required String key, required int value})
 ```
 
-| Parameter | Type | Required | Description |
-|---|---|---|---|
-| `key` | `String` | Yes | Data key (must not be empty) |
-| `value` | `int` | Yes | Integer value |
+| Parameter | Type     | Required | Description                  |
+|-----------|----------|----------|------------------------------|
+| `key`     | `String` | Yes      | Data key (must not be empty) |
+| `value`   | `int`    | Yes      | Integer value                |
 
 **Throws:** `ArgumentError` if `key` is empty.
 
@@ -120,10 +120,10 @@ static void setSessionSegments({
 })
 ```
 
-| Parameter | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `segments` | `List<String>` | Yes | — | Segment strings |
-| `overwrite` | `bool` | No | `false` | Replace existing segments if `true` |
+| Parameter   | Type           | Required | Default | Description                         |
+|-------------|----------------|----------|---------|-------------------------------------|
+| `segments`  | `List<String>` | Yes      | —       | Segment strings                     |
+| `overwrite` | `bool`         | No       | `false` | Replace existing segments if `true` |
 
 ---
 
@@ -138,10 +138,10 @@ static Future<void> pushSessionEvent({
 })
 ```
 
-| Parameter | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `name` | `String` | Yes | — | Event name |
-| `color` | `SessionEventColor` | No | `blue` | Event color in the dashboard |
+| Parameter | Type                | Required | Default | Description                  |
+|-----------|---------------------|----------|---------|------------------------------|
+| `name`    | `String`            | Yes      | —       | Event name                   |
+| `color`   | `SessionEventColor` | No       | `blue`  | Event color in the dashboard |
 
 ---
 
@@ -157,13 +157,39 @@ static Future<int?> getUnreadMessageCount({
 })
 ```
 
-| Parameter | Type | Required | Description |
-|---|---|---|---|
-| `websiteId` | `String` | Yes | Your Crisp Website ID |
-| `identifier` | `String` | Yes | Crisp REST API Identifier |
-| `key` | `String` | Yes | Crisp REST API Key |
+| Parameter    | Type     | Required | Description               |
+|--------------|----------|----------|---------------------------|
+| `websiteId`  | `String` | Yes      | Your Crisp Website ID     |
+| `identifier` | `String` | Yes      | Crisp REST API Identifier |
+| `key`        | `String` | Yes      | Crisp REST API Key        |
 
 **Returns:** Unread count as `int`, or `null` if no session or error.
+
+::: warning iOS
+On iOS, `unread.visitor` may not reset after reading chat in the native SDK. Use [markMessagesAsRead](#markmessagesasread) as a workaround.
+:::
+
+---
+
+### markMessagesAsRead
+
+Marks all operator messages as read via the Crisp REST API. Workaround for iOS when the native SDK does not sync read receipts.
+
+```dart
+static Future<bool?> markMessagesAsRead({
+  required String websiteId,
+  required String identifier,
+  required String key,
+})
+```
+
+| Parameter    | Type     | Required | Description               |
+|--------------|----------|----------|---------------------------|
+| `websiteId`  | `String` | Yes      | Your Crisp Website ID     |
+| `identifier` | `String` | Yes      | Crisp REST API Identifier |
+| `key`        | `String` | Yes      | Crisp REST API Key        |
+
+**Returns:** `true` if accepted (HTTP 202), `false` on error, `null` if no session.
 
 ---
 
@@ -187,9 +213,9 @@ Sets a callback for when a Crisp notification is tapped while the app is in the 
 static void setOnNotificationTappedCallback(VoidCallback? callback)
 ```
 
-| Parameter | Type | Required | Description |
-|---|---|---|---|
-| `callback` | `VoidCallback?` | Yes | Callback function, or `null` to remove |
+| Parameter  | Type            | Required | Description                            |
+|------------|-----------------|----------|----------------------------------------|
+| `callback` | `VoidCallback?` | Yes      | Callback function, or `null` to remove |
 
 **Note:** Requires `import 'dart:ui';` for `VoidCallback`. Only fires on Android.
 

--- a/docsrc/docs/reference/faq.md
+++ b/docsrc/docs/reference/faq.md
@@ -90,6 +90,10 @@ It returns `null` if:
 - The API credentials are invalid
 - A network error occurred
 
+### Why does `getUnreadMessageCount` stay non-zero on iOS after reading chat?
+
+The Crisp iOS SDK may not send read receipts to the server. Call `markMessagesAsRead()` after the visitor closes chat. See [Unread Messages — iOS limitation](/core_feature/unread_messages#ios-limitation-unread-count-not-clearing-after-reading-chat).
+
 ## Sessions
 
 ### Why does `getSessionIdentifier` return null?

--- a/docsrc/docs/troubleshooting/common_issues.md
+++ b/docsrc/docs/troubleshooting/common_issues.md
@@ -103,6 +103,14 @@ Possible causes:
 - Network error
 - The `websiteId` doesn't match your Crisp workspace
 
+### `getUnreadMessageCount` stays non-zero on iOS after reading chat
+
+On iOS, the Crisp native SDK may not send read receipts to the server when the visitor reads operator messages. The REST field `unread.visitor` reflects **server-side** state — if it stays non-zero after closing chat, the iOS SDK did not update it.
+
+**Workaround:** Call `FlutterCrispChat.markMessagesAsRead()` after the visitor closes chat, then re-fetch the count. See [Unread Messages — iOS limitation](/core_feature/unread_messages#ios-limitation-unread-count-not-clearing-after-reading-chat).
+
+**Report upstream:** Use [docs/crisp-sdk-ios-unread-issue.md](https://github.com/alamin-karno/flutter-crisp-chat/blob/main/docs/crisp-sdk-ios-unread-issue.md) to file an issue on [crisp-im/crisp-sdk-ios](https://github.com/crisp-im/crisp-sdk-ios).
+
 ### `ArgumentError` when opening chat
 
 The plugin validates `email` and `company URL` formats. Ensure:

--- a/docsrc/docs/troubleshooting/platform_specific.md
+++ b/docsrc/docs/troubleshooting/platform_specific.md
@@ -108,6 +108,24 @@ If the app crashes when the user tries to take a photo or access the camera in c
 
 If `resetCrispChatSession` crashes on iOS, ensure you're using version `2.0.9` or later, which fixed this issue ([#20](https://github.com/alamin-karno/flutter-crisp-chat/issues/20)).
 
+### iOS unread count not clearing
+
+After opening chat, reading all operator messages, and closing the UI, `getUnreadMessageCount()` may still return a non-zero value. A direct `GET /v1/website/{website_id}/conversation/{session_id}` shows the same stale `unread.visitor` — this is a **Crisp iOS SDK limitation** (read receipts not synced to the server).
+
+**Workaround:**
+
+```dart
+await FlutterCrispChat.markMessagesAsRead(
+  websiteId: websiteId,
+  identifier: identifier,
+  key: key,
+);
+```
+
+**Verify:** Run `./scripts/verify_unread_read_receipts.sh full` with your REST credentials. If manual `PATCH /read` clears the count but reading in chat does not, file an issue using [docs/crisp-sdk-ios-unread-issue.md](https://github.com/alamin-karno/flutter-crisp-chat/blob/main/docs/crisp-sdk-ios-unread-issue.md).
+
+Compare with Android using the same REST GET steps — if Android clears `unread.visitor` after reading but iOS does not, the bug is iOS-specific.
+
 ### CocoaPods vs Swift Package Manager
 
 The plugin supports both CocoaPods and Swift Package Manager (SPM) for iOS dependency management. If you encounter issues with one, try the other:

--- a/lib/crisp_chat.dart
+++ b/lib/crisp_chat.dart
@@ -181,10 +181,26 @@ class FlutterCrispChat {
     );
   }
 
+  static Map<String, String> _crispApiHeaders({
+    required String identifier,
+    required String key,
+    bool jsonBody = false,
+  }) {
+    return {
+      'Authorization': 'Basic ${base64Encode(utf8.encode('$identifier:$key'))}',
+      'X-Crisp-Tier': 'plugin',
+      if (jsonBody) 'Content-Type': 'application/json',
+    };
+  }
+
   /// Fetches the unread message count for the current visitor session.
   ///
   /// This method makes a REST API call to Crisp to get conversation details,
   /// including the number of unread messages for the visitor.
+  ///
+  /// On iOS, the native Crisp SDK may not send read receipts to the server
+  /// when the visitor reads messages. In that case, [unread.visitor](https://docs.crisp.chat/references/rest-api/v1/#get-a-conversation)
+  /// stays non-zero until you call [markMessagesAsRead].
   ///
   /// {@category General}
   /// @param websiteId Your Crisp Website ID.
@@ -210,15 +226,11 @@ class FlutterCrispChat {
     final uri = Uri.parse(
       'https://api.crisp.chat/v1/website/$websiteId/conversation/$sessionId',
     );
-    final credentials = base64Encode(utf8.encode('$identifier:$key'));
 
     try {
       final response = await http.get(
         uri,
-        headers: {
-          'Authorization': 'Basic $credentials',
-          'X-Crisp-Tier': 'plugin',
-        },
+        headers: _crispApiHeaders(identifier: identifier, key: key),
       );
 
       if (kDebugMode) {
@@ -246,6 +258,75 @@ class FlutterCrispChat {
       );
 
       return null;
+    }
+  }
+
+  /// Marks all operator messages as read for the current visitor session.
+  ///
+  /// Calls the Crisp REST API [Mark Messages As Read In Conversation](https://docs.crisp.chat/references/rest-api/v1/#mark-messages-as-read-in-conversation)
+  /// endpoint. Use this as a workaround on iOS when the native SDK does not
+  /// reset [unread.visitor](https://docs.crisp.chat/references/rest-api/v1/#get-a-conversation)
+  /// after the visitor reads messages in chat.
+  ///
+  /// {@category General}
+  /// @param websiteId Your Crisp Website ID.
+  /// @param identifier Your Crisp REST API Identifier.
+  /// @param key Your Crisp REST API Key.
+  /// @return `true` if the request was accepted (HTTP 202), `false` on API
+  ///         error, or `null` if no active session exists.
+  static Future<bool?> markMessagesAsRead({
+    required String websiteId,
+    required String identifier,
+    required String key,
+  }) async {
+    final sessionId = await getSessionIdentifier();
+    if (sessionId == null) {
+      log(
+        'No active session, cannot mark messages as read.',
+        name: 'FlutterCrispChat',
+      );
+      return null;
+    }
+
+    final uri = Uri.parse(
+      'https://api.crisp.chat/v1/website/$websiteId/conversation/$sessionId/read',
+    );
+
+    try {
+      final response = await http.patch(
+        uri,
+        headers: _crispApiHeaders(
+          identifier: identifier,
+          key: key,
+          jsonBody: true,
+        ),
+        body: jsonEncode({
+          'from': 'operator',
+          'origin': 'chat',
+        }),
+      );
+
+      if (kDebugMode) {
+        log('URL: $uri - STATUS: ${response.statusCode}', name: 'API');
+        log('BODY: ${response.body}', name: 'API');
+      }
+
+      if (response.statusCode == 202) {
+        return true;
+      }
+
+      log(
+        'Failed to mark messages as read. Status: ${response.statusCode}, Body: ${response.body}',
+        name: 'FlutterCrispChat',
+      );
+      return false;
+    } catch (e, stackTrace) {
+      log(
+        'An error occurred while marking messages as read: $e',
+        stackTrace: stackTrace,
+        name: 'FlutterCrispChat',
+      );
+      return false;
     }
   }
 

--- a/scripts/file-crisp-ios-unread-issue.sh
+++ b/scripts/file-crisp-ios-unread-issue.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Files a pre-written issue on crisp-im/crisp-sdk-ios using the GitHub CLI.
+#
+# Prerequisites:
+#   brew install gh && gh auth login
+#
+# Usage:
+#   ./scripts/file-crisp-ios-unread-issue.sh
+
+set -euo pipefail
+
+REPO="crisp-im/crisp-sdk-ios"
+ISSUE_FILE="$(cd "$(dirname "$0")/.." && pwd)/docs/crisp-sdk-ios-unread-issue.md"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: GitHub CLI (gh) is not installed." >&2
+  echo "Install: brew install gh && gh auth login" >&2
+  echo "Or file manually: https://github.com/${REPO}/issues/new" >&2
+  echo "Body template: ${ISSUE_FILE}" >&2
+  exit 1
+fi
+
+TITLE="iOS SDK does not reset unread.visitor after visitor reads operator messages in ChatViewController"
+
+# Extract body from markdown (skip title line and front separator)
+BODY="$(awk 'NR>4' "$ISSUE_FILE")"
+
+gh issue create \
+  --repo "$REPO" \
+  --title "$TITLE" \
+  --body "$BODY"
+
+echo "Issue filed on https://github.com/${REPO}/issues"

--- a/scripts/verify_unread_read_receipts.sh
+++ b/scripts/verify_unread_read_receipts.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Verifies whether Crisp REST unread.visitor is cleared after reading chat in the
+# native mobile SDK, and whether manual PATCH /read works as a control test.
+#
+# Required environment variables:
+#   CRISP_WEBSITE_ID   - Crisp website identifier
+#   CRISP_IDENTIFIER   - Marketplace plugin REST API identifier
+#   CRISP_KEY          - Marketplace plugin REST API key
+#   CRISP_SESSION_ID   - Active conversation session ID (from getSessionIdentifier)
+#
+# Usage:
+#   export CRISP_WEBSITE_ID=... CRISP_IDENTIFIER=... CRISP_KEY=... CRISP_SESSION_ID=...
+#   ./scripts/verify_unread_read_receipts.sh get          # read current unread.visitor
+#   ./scripts/verify_unread_read_receipts.sh mark-read    # PATCH /read (control test)
+#   ./scripts/verify_unread_read_receipts.sh full         # get → mark-read → get
+
+set -euo pipefail
+
+API_BASE="https://api.crisp.chat/v1"
+
+require_env() {
+  local missing=0
+  for var in CRISP_WEBSITE_ID CRISP_IDENTIFIER CRISP_KEY CRISP_SESSION_ID; do
+    if [[ -z "${!var:-}" ]]; then
+      echo "ERROR: $var is not set" >&2
+      missing=1
+    fi
+  done
+  if [[ "$missing" -eq 1 ]]; then
+    echo >&2
+    echo "Set credentials from your Crisp Marketplace plugin token." >&2
+    echo "Session ID comes from FlutterCrispChat.getSessionIdentifier()." >&2
+    exit 1
+  fi
+}
+
+auth_header() {
+  printf 'Basic %s' "$(printf '%s:%s' "$CRISP_IDENTIFIER" "$CRISP_KEY" | base64)"
+}
+
+get_unread_visitor() {
+  local response
+  response="$(curl -sS \
+    -H "Authorization: $(auth_header)" \
+    -H "X-Crisp-Tier: plugin" \
+    "${API_BASE}/website/${CRISP_WEBSITE_ID}/conversation/${CRISP_SESSION_ID}")"
+
+  echo "$response" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+unread = data.get('data', {}).get('unread', {})
+print(json.dumps(unread, indent=2))
+visitor = unread.get('visitor')
+if visitor is None:
+    sys.exit(2)
+print(f'unread.visitor={visitor}', file=sys.stderr)
+"
+}
+
+mark_read() {
+  curl -sS -X PATCH \
+    -H "Authorization: $(auth_header)" \
+    -H "X-Crisp-Tier: plugin" \
+    -H "Content-Type: application/json" \
+    -d '{"from":"operator","origin":"chat"}' \
+    "${API_BASE}/website/${CRISP_WEBSITE_ID}/conversation/${CRISP_SESSION_ID}/read" \
+    -w "\nHTTP_STATUS:%{http_code}\n"
+}
+
+cmd="${1:-get}"
+require_env
+
+case "$cmd" in
+  get)
+    echo "GET conversation unread counters:"
+    get_unread_visitor
+    ;;
+  mark-read)
+    echo "PATCH mark messages as read:"
+    mark_read
+    echo
+    echo "Waiting 3s for server to update..."
+    sleep 3
+    echo "GET conversation unread counters after mark-read:"
+    get_unread_visitor
+    ;;
+  full)
+    echo "=== Step 1: GET unread before mark-read ==="
+    get_unread_visitor
+    echo
+    echo "=== Step 2: PATCH mark-read (control test) ==="
+    mark_read
+    echo
+    echo "Waiting 3s..."
+    sleep 3
+    echo "=== Step 3: GET unread after mark-read ==="
+    get_unread_visitor
+    echo
+    echo "If step 3 shows unread.visitor=0, REST mark-read works."
+    echo "If unread stayed >0 after reading in iOS chat but step 3 is 0, the iOS SDK read-receipt path is broken."
+    ;;
+  *)
+    echo "Usage: $0 {get|mark-read|full}" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
- Implement `markMessagesAsRead` in `FlutterCrispChat` to manually clear unread counts via the Crisp REST API
- Add documentation and verification scripts to address the iOS SDK limitation where unread counts do not sync automatically
- Refactor internal REST API header generation into a private helper method
- Update troubleshooting guides, FAQ, and API reference with iOS-specific workarounds and bug report templates