### PR TITLE
Add documentation for Crisp dashboard domain lock requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,9 @@ Future<void> main() async {
 ---
 Go to your [Crisp Dashboard](https://app.crisp.chat/), and copy your Website ID:
 
-![Crisp Dashboard](https://github.com/user-attachments/assets/ef6b9932-8141-4108-8f11-f5f3b40cbe15)      
+![Crisp Dashboard](https://github.com/user-attachments/assets/ef6b9932-8141-4108-8f11-f5f3b40cbe15)
+
+- **Android / iOS:** disable **Lock the chatbox to website domain (and subdomains)** under **Settings** → **Website Settings** → **Chatbox & Email Settings** → **Chatbox Security**. With domain lock enabled, chat fails with **"Error starting chat"** even when the Website ID is valid. See [docs — Chatbox Security](https://alamin-karno.github.io/flutter-crisp-chat/core_feature/configuration.html#crisp-dashboard-chatbox-security).
 
 ### 5. Setup your flutter app to use Crisp
 ---

--- a/docsrc/docs/core_feature/configuration.md
+++ b/docsrc/docs/core_feature/configuration.md
@@ -55,6 +55,27 @@ Your Website ID is found in the [Crisp Dashboard](https://app.crisp.chat/) under
 
 ![Crisp Dashboard](https://github.com/user-attachments/assets/ef6b9932-8141-4108-8f11-f5f3b40cbe15)
 
+## Crisp dashboard: Chatbox Security
+
+In the [Crisp Dashboard](https://app.crisp.chat/), go to **Settings** → **Website Settings** → **Chatbox & Email Settings** → **Chatbox Security** and find **Lock the chatbox to website domain (and subdomains)**.
+
+::: warning Android and iOS (native SDK)
+This setting must be **disabled** when using the native Crisp SDK on **Android and iOS**. Domain lock validates browser page origins; mobile apps have no matching website domain, so the SDK session is rejected. You may see **"Error starting chat"** or a misleading `invalid_website_id` WebSocket error even when your Website ID is valid — `GET https://api.crisp.chat/v1/website/{websiteId}` can still return 200.
+
+See [Crisp Android SDK](https://docs.crisp.chat/guides/chatbox-sdks/android-sdk/) and [Crisp iOS SDK](https://docs.crisp.chat/guides/chatbox-sdks/ios-sdk/) for the same requirement. Reported in [#148](https://github.com/alamin-karno/flutter-crisp-chat/issues/148).
+:::
+
+### Domain lock by platform
+
+| Platform                       | Domain lock            | Guidance                                                                                                                                                                                                                                                                                        |
+|--------------------------------|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Android / iOS**              | Must be **disabled**   | Native SDK has no browser origin; session is rejected → `Error starting chat` / misleading `invalid_website_id` ([#148](https://github.com/alamin-karno/flutter-crisp-chat/issues/148))                                                                                                         |
+| **Web**                        | Can stay **enabled**   | Crisp validates the **page origin**. Host your Flutter web app on a domain (or subdomain) allowed in the dashboard lock list — e.g. if lock allows `example.com`, deploy at `https://app.example.com` or `https://example.com`. Local dev (`localhost`) may fail unless that origin is allowed. |
+| **Desktop (embedded WebView)** | Should be **disabled** | Chat loads from a temporary `file://` page; there is no website origin to match, similar to mobile.                                                                                                                                                                                             |
+| **Desktop (browser fallback)** | Should be **disabled** | Opens `https://app.crisp.chat/website/{id}/`, which is not your locked domain. Prefer disabling domain lock or use embedded WebView after fixing WebView2/WebKitGTK.                                                                                                                            |
+
+If chat fails to connect on Web with domain lock enabled, check `window.location.origin` in DevTools against your allowed domains. See [Platform-Specific — Web](/troubleshooting/platform_specific#domain-lock-enabled) and [Platform-Specific — Desktop](/troubleshooting/platform_specific#domain-lock-enabled-1).
+
 ## Token ID
 
 The `tokenId` is used to identify returning users. When a user opens the chat with the same `tokenId`, Crisp will restore their previous conversation history. This is useful for:

--- a/docsrc/docs/getting_started/platform_setup.md
+++ b/docsrc/docs/getting_started/platform_setup.md
@@ -106,6 +106,12 @@ The Crisp iOS SDK requires iOS 13.0+. Ensure your `ios/Podfile` has:
 platform :ios, '13.0'
 ```
 
+## Crisp dashboard (Android & iOS)
+
+Before opening chat on native mobile targets:
+
+- Disable **Lock the chatbox to website domain (and subdomains)** under **Settings** → **Website Settings** → **Chatbox & Email Settings** → **Chatbox Security**. See [Configuration — Chatbox Security](/core_feature/configuration#crisp-dashboard-chatbox-security).
+
 ## Web
 
 No native Crisp SDK install. When you call `openCrispChat`, the plugin loads the official script from `https://client.crisp.chat/l.js` and opens the Crisp chatbox in the page.
@@ -115,6 +121,7 @@ No native Crisp SDK install. When you call `openCrispChat`, the plugin loads the
 3. **Identity verification:** only set `User.signature` when it is a real HMAC-SHA256 hex string from your server (32+ hex characters). Fake placeholders can leave the chat on the loading skeleton.
 4. **Content-Security-Policy (optional):** if your site uses CSP, allow scripts and connections to `https://client.crisp.chat` and `https://*.crisp.chat`.
 5. **REST API on web:** `getUnreadMessageCount` / `markMessagesAsRead` accept credentials in Dart; those values are visible in the browser — use a **backend proxy** in production.
+6. **Domain lock (optional):** if **Lock the chatbox to website domain** is enabled, host the app on an allowed domain or subdomain and verify the page origin if chat fails to connect. See [Configuration — Chatbox Security](/core_feature/configuration#crisp-dashboard-chatbox-security).
 
 `openChatboxFromNotification`, `setOnNotificationTappedCallback`, `CrispConfig.enableNotifications`, and `modalPresentationStyle` have no effect on Web.
 
@@ -171,6 +178,15 @@ sudo apt install libwebkit2gtk-4.1-dev
 ```
 
 (Or `libwebkit2gtk-4.0-dev` on older distributions.)
+
+### 5. Domain lock
+
+Disable **Lock the chatbox to website domain** for desktop chat:
+
+- **Embedded WebView** loads chat from a temporary `file://` page — there is no website origin to match (same constraint as mobile).
+- **Browser fallback** opens `https://app.crisp.chat/website/{id}/`, which also conflicts with domain lock.
+
+See [Configuration — Chatbox Security](/core_feature/configuration#crisp-dashboard-chatbox-security).
 
 ### Browser fallback
 

--- a/docsrc/docs/getting_started/quick_start.md
+++ b/docsrc/docs/getting_started/quick_start.md
@@ -33,6 +33,10 @@ Go to your [Crisp Dashboard](https://app.crisp.chat/), navigate to **Settings** 
 
 ![Crisp Dashboard](https://github.com/user-attachments/assets/ef6b9932-8141-4108-8f11-f5f3b40cbe15)
 
+::: warning Android and iOS
+Before testing on Android or iOS, disable **Lock the chatbox to website domain (and subdomains)** in the Crisp dashboard (**Settings** → **Website Settings** → **Chatbox & Email Settings** → **Chatbox Security**). With domain lock enabled, chat fails with **"Error starting chat"** even when the Website ID is valid. See [Configuration — Chatbox Security](/core_feature/configuration#crisp-dashboard-chatbox-security).
+:::
+
 ## Minimal Example
 
 ```dart

--- a/docsrc/docs/getting_started/supported_platforms.md
+++ b/docsrc/docs/getting_started/supported_platforms.md
@@ -102,6 +102,16 @@ No extra native setup. The plugin loads `https://client.crisp.chat/l.js` when yo
 
 If you use a strict Content-Security-Policy, allow scripts and connections to `https://client.crisp.chat` and `https://*.crisp.chat`.
 
+## Crisp dashboard: domain lock
+
+**Lock the chatbox to website domain (and subdomains)** is under **Settings** → **Website Settings** → **Chatbox & Email Settings** → **Chatbox Security**. Behavior by platform:
+
+- **Android / iOS** — disable domain lock (native SDK has no browser origin).
+- **Web** — can stay enabled if your app is served from an allowed domain or subdomain.
+- **Desktop** — disable domain lock (embedded WebView uses `file://`; browser fallback opens `app.crisp.chat`).
+
+Full details: [Configuration — Chatbox Security](/core_feature/configuration#crisp-dashboard-chatbox-security).
+
 ## Minimum versions
 
 - **Dart SDK**: 3.5.0+

--- a/docsrc/docs/reference/faq.md
+++ b/docsrc/docs/reference/faq.md
@@ -50,6 +50,12 @@ Go to your [Crisp Dashboard](https://app.crisp.chat/) > **Settings** > **Website
 
 ## Configuration
 
+### Why does chat show "Error starting chat" even with a valid Website ID?
+
+On **Android and iOS**, **Lock the chatbox to website domain (and subdomains)** must be **disabled** in the Crisp dashboard. Domain lock validates browser origins; the native mobile SDK has no matching origin, so the session is rejected. Logs may show a misleading `invalid_website_id` WebSocket error even though REST `GET /v1/website/{id}` still returns 200.
+
+Disable the setting under **Settings** → **Website Settings** → **Chatbox & Email Settings** → **Chatbox Security**, restart the app, and try again. See [Configuration — Chatbox Security](/core_feature/configuration#crisp-dashboard-chatbox-security) and [Common Issues — Chat not opening](/troubleshooting/common_issues#chat-not-opening).
+
 ### What is `tokenId` used for?
 
 The `tokenId` identifies returning users. When a user opens the chat with the same `tokenId`, Crisp restores their previous conversation. Use a stable unique identifier like your app's user ID.

--- a/docsrc/docs/troubleshooting/common_issues.md
+++ b/docsrc/docs/troubleshooting/common_issues.md
@@ -123,10 +123,34 @@ The plugin validates `email` and `company URL` formats. Ensure:
 
 ### Chat not opening
 
+#### "Error starting chat" / `invalid_website_id` in logs
+
+Primarily affects **Android and iOS**; see [Platform-Specific — Web](/troubleshooting/platform_specific#domain-lock-enabled) and [Platform-Specific — Desktop](/troubleshooting/platform_specific#domain-lock-enabled-1) for Web/desktop.
+
+| Item                | Detail                                                                                                                                            |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| Symptom             | Chat fails to load; native logs show `invalid_website_id` or `(Initialization Error) Error starting chat`                                         |
+| Common misdiagnosis | Website ID looks valid; REST website lookup succeeds                                                                                              |
+| Cause               | **Lock the chatbox to website domain** enabled in Crisp dashboard                                                                                 |
+| Fix                 | Disable domain lock under **Settings** → **Website Settings** → **Chatbox & Email Settings** → **Chatbox Security**, fully restart the app, retry |
+
+Example log lines:
+
+```
+E/CrispSocket: A websocket error occured.
+E/CrispSocket: Name: session:created
+E/CrispSocket: Args: [ invalid_website_id ]
+E/CrispSocket: (Initialization Error) Error starting chat
+```
+
+Behavior can be **intermittent** — chat may work once, then fail until domain lock is disabled. See [Configuration — Chatbox Security](/core_feature/configuration#crisp-dashboard-chatbox-security) and [#148](https://github.com/alamin-karno/flutter-crisp-chat/issues/148).
+
+If domain lock is already disabled, also check:
+
 1. Verify your `websiteID` is correct (copy from Crisp dashboard)
 2. Check that `websiteID` is not empty
 3. Ensure the device has internet connectivity
-4. Check the debug console for error messages
+4. Check the debug console for other error messages
 
 ### Session data not appearing in Crisp dashboard
 

--- a/docsrc/docs/troubleshooting/platform_specific.md
+++ b/docsrc/docs/troubleshooting/platform_specific.md
@@ -145,6 +145,16 @@ The gray/blue placeholder bars mean the chat **shell** opened but the **session*
 4. Check DevTools → **Network** for failed requests to `client.crisp.chat` or `storage.crisp.chat`.
 5. Hard-refresh the page (`Cmd+Shift+R`) after upgrading the plugin so `l.js` is not cached from an old run.
 
+### Domain lock enabled
+
+If **Lock the chatbox to website domain** is enabled in the Crisp dashboard:
+
+- **Symptom:** skeleton UI / session never connects
+- **Check:** run `window.location.origin` in DevTools and compare with allowed domains in the dashboard
+- **Fix:** add the origin to the lock list, disable domain lock, or deploy to an allowed host
+
+See [Configuration — Chatbox Security](/core_feature/configuration#crisp-dashboard-chatbox-security).
+
 ### Chat does not appear
 
 1. Confirm `openCrispChat` was called with a valid `websiteID`.
@@ -156,6 +166,15 @@ The gray/blue placeholder bars mean the chat **shell** opened but the **session*
 `getUnreadMessageCount` and `markMessagesAsRead` use your Crisp REST credentials from Dart. On Web, those values are visible to users — prefer a backend proxy for production.
 
 ## Desktop (macOS, Windows, Linux)
+
+### Domain lock enabled
+
+If **Lock the chatbox to website domain** is enabled in the Crisp dashboard:
+
+- **Embedded WebView** loads chat from a temporary `file://` page — disable domain lock (same as mobile).
+- **Browser fallback** opens `https://app.crisp.chat/website/{id}/`, which is also incompatible with domain lock — install WebView2 (Windows) or WebKitGTK (Linux) for embedded chat instead.
+
+See [Configuration — Chatbox Security](/core_feature/configuration#crisp-dashboard-chatbox-security).
 
 ### Embedded WebView does not open
 


### PR DESCRIPTION
- Detail the requirement to disable "Lock the chatbox to website domain" for Android, iOS, and Desktop platforms to prevent initialization errors
- Add troubleshooting steps for "Error starting chat" and `invalid_website_id` log errors
- Update the README, FAQ, and platform-specific setup guides with domain lock configuration instructions
- Provide a platform comparison table for Chatbox Security settings in the configuration documentation