### PR TITLE
docs: Add "Next Steps" sections and update documentation navigation

### DIFF
--- a/docsrc/docs/community/author.md
+++ b/docsrc/docs/community/author.md
@@ -87,3 +87,7 @@ This plugin wouldn't be where it is without the help of the community. Thank you
 [![Contributors](https://contrib.rocks/image?repo=alamin-karno/flutter-crisp-chat)](https://github.com/alamin-karno/flutter-crisp-chat/graphs/contributors)
 
 Want to contribute? See the [Contributing Guide](/community/contributing).
+
+## Next Steps
+
+- [Support](/community/support) — Support the project

--- a/docsrc/docs/community/contributing.md
+++ b/docsrc/docs/community/contributing.md
@@ -146,3 +146,8 @@ flutter-crisp-chat/
 - Message the [maintainer](/community/author) for clarification
 
 Thank you for contributing!
+
+## Next Steps
+
+- [Author & Maintainer](/community/author) — About the maintainer
+- [Support](/community/support) — Support the project

--- a/docsrc/docs/community/support.md
+++ b/docsrc/docs/community/support.md
@@ -91,3 +91,7 @@ These companies use the Flutter Crisp Chat plugin:
 - [L'Algo de Paulo](https://lalgodepaulo.com/)
 
 *Using this plugin in your app? [Let us know](https://github.com/alamin-karno/flutter-crisp-chat/issues) and we'll add you to the list!*
+
+## Next Steps
+
+- [Contributing](/community/contributing) — How to contribute to the project

--- a/docsrc/docs/core_feature/configuration.md
+++ b/docsrc/docs/core_feature/configuration.md
@@ -13,8 +13,8 @@ prev:
   link: '/getting_started/quick_start'
 
 next:
-  text: 'User & Company'
-  link: '/core_feature/user_and_company'
+  text: 'iOS Features'
+  link: '/core_feature/ios_features'
 ---
 
 # Configuration
@@ -181,6 +181,6 @@ The `modalPresentationStyle` parameter only affects iOS devices. On Android, Cri
 
 ## Next Steps
 
-- [Session Management](/core_feature/session_management) — Set custom session data, segments, and events
 - [iOS Features](/core_feature/ios_features) — Detailed guide on iOS specific feature configuration
+- [User & Company](/core_feature/user_and_company) — Set user and company details in CrispConfig
 

--- a/docsrc/docs/getting_started/overview.md
+++ b/docsrc/docs/getting_started/overview.md
@@ -71,3 +71,8 @@ next:
 - [GitHub Repository](https://github.com/alamin-karno/flutter-crisp-chat)
 - [Issue Tracker](https://github.com/alamin-karno/flutter-crisp-chat/issues)
 - [Changelog](/reference/changelog)
+
+## Next Steps
+
+- [Installation](/getting_started/install) — Add the package to your project
+- [Platform Setup](/getting_started/platform_setup) — Android, iOS, Web, and desktop configuration

--- a/docsrc/docs/getting_started/platform_setup.md
+++ b/docsrc/docs/getting_started/platform_setup.md
@@ -13,8 +13,8 @@ prev:
   link: '/getting_started/install'
 
 next:
-  text: 'Quick Start'
-  link: '/getting_started/quick_start'
+  text: 'Supported Platforms'
+  link: '/getting_started/supported_platforms'
 ---
 
 # Platform Setup
@@ -247,6 +247,7 @@ More detail: [Supported Platforms — Desktop](/getting_started/supported_platfo
 
 ## Next Steps
 
-With platform setup complete, you're ready to open your first chat. See [Quick Start](/getting_started/quick_start).
+- [Supported Platforms](/getting_started/supported_platforms) — Platform support matrix for Android, iOS, Web, and desktop
+- [Quick Start](/getting_started/quick_start) — Open your first chat in 5 minutes
 
 For push notification setup (Firebase, APNs) on **Android and iOS only**, see [Firebase Setup](/notifications/firebase_setup).

--- a/docsrc/docs/getting_started/quick_start.md
+++ b/docsrc/docs/getting_started/quick_start.md
@@ -9,8 +9,8 @@ head:
       content: "flutter crisp chat quick start, crisp chat hello world, flutter crisp chat example, open crisp chat flutter"
 
 prev:
-  text: 'Platform Setup'
-  link: '/getting_started/platform_setup'
+  text: 'Supported Platforms'
+  link: '/getting_started/supported_platforms'
 
 next:
   text: 'Configuration'
@@ -95,12 +95,9 @@ Use the same `openCrispChat` call; no separate Web API. See [Supported Platforms
 `enableNotifications` and `modalPresentationStyle` apply to Android/iOS only. On Web and desktop they are ignored.
 :::
 
-## What's Next?
+## Next Steps
 
 Now that you have a basic chat working, explore the full capabilities:
 
 - [Configuration](/core_feature/configuration) — Customize `CrispConfig` with user details, tokens, and segments
-- [User & Company](/core_feature/user_and_company) — Identify users with email, name, phone, avatar, and company info
-- [Session Management](/core_feature/session_management) — Set custom session data, segments, events, and reset sessions
-- [Push Notifications](/notifications/firebase_setup) — Enable FCM and APNs notifications
-- [Unread Messages](/core_feature/unread_messages) — Query unread message count via REST API
+- [iOS Features](/core_feature/ios_features) — iOS-specific modal presentation and notification settings

--- a/docsrc/docs/getting_started/supported_platforms.md
+++ b/docsrc/docs/getting_started/supported_platforms.md
@@ -7,6 +7,14 @@ head:
   - - meta
     - name: keywords
       content: "flutter crisp chat web, crisp chat desktop, flutter crisp platforms"
+
+prev:
+  text: 'Platform Setup'
+  link: '/getting_started/platform_setup'
+
+next:
+  text: 'Quick Start'
+  link: '/getting_started/quick_start'
 ---
 
 # Supported platforms
@@ -130,3 +138,8 @@ Full details: [Configuration — Chatbox Security](/core_feature/configuration#c
 - **Flutter**: 3.24.0+
 - **Android**: API 23+ (unchanged)
 - **iOS**: 13.0+ (unchanged)
+
+## Next Steps
+
+- [Quick Start](/getting_started/quick_start) — Open your first chat in 5 minutes
+- [Configuration](/core_feature/configuration) — Customize `CrispConfig` with user details, tokens, and segments

--- a/docsrc/docs/notifications/handling.md
+++ b/docsrc/docs/notifications/handling.md
@@ -179,3 +179,8 @@ Sets a callback that fires when a Crisp notification is tapped while the app is 
 3. The plugin's `NewIntentListener` detects the new intent and invokes `onCrispNotificationTapped` on the Flutter method channel
 4. Your Dart callback fires, and you call `openChatboxFromNotification()`
 5. The plugin calls `CrispNotificationClient.openChatbox(activity, intent)` to open the chat
+
+## Next Steps
+
+- [API Documentation](/reference/api_documentation) — Complete method documentation
+- [Full Example](/reference/examples) — Working example app code

--- a/docsrc/docs/reference/api_documentation.md
+++ b/docsrc/docs/reference/api_documentation.md
@@ -325,3 +325,9 @@ enum SessionEventColor {
   black, blue, brown, green, grey,
   orange, pink, purple, red, yellow,
 }
+```
+
+## Next Steps
+
+- [Full Example](/reference/examples) — Working example app code
+- [FAQ](/reference/faq) — Frequently asked questions

--- a/docsrc/docs/reference/changelog.md
+++ b/docsrc/docs/reference/changelog.md
@@ -178,3 +178,7 @@ All notable changes to the `crisp_chat` package are documented here. For the ful
 
 ## 0.0.1
 - Initial release — Crisp Chat for native Android & iOS platforms
+
+## Next Steps
+
+- [Common Issues](/troubleshooting/common_issues) — Troubleshooting guide

--- a/docsrc/docs/reference/examples.md
+++ b/docsrc/docs/reference/examples.md
@@ -255,3 +255,8 @@ flutter run --dart-define-from-file=config.json
 ## Screenshot
 
 ![Crisp Chat SDK Demo](https://github.com/user-attachments/assets/436a53d5-f37b-4aa4-982d-e023fe35ab30)
+
+## Next Steps
+
+- [FAQ](/reference/faq) — Frequently asked questions
+- [Changelog](/reference/changelog) — Version history and release notes

--- a/docsrc/docs/reference/faq.md
+++ b/docsrc/docs/reference/faq.md
@@ -140,3 +140,8 @@ Yes. Call `setSessionString`, `setSessionInt`, and `setSessionSegments` before `
 - [Open an issue on GitHub](https://github.com/alamin-karno/flutter-crisp-chat/issues)
 - Check the [Troubleshooting](/troubleshooting/common_issues) page
 - See the [Crisp Help Center](https://help.crisp.chat/en/) for Crisp-specific questions
+
+## Next Steps
+
+- [Changelog](/reference/changelog) — Version history and release notes
+- [Common Issues](/troubleshooting/common_issues) — Troubleshooting guide

--- a/docsrc/docs/troubleshooting/common_issues.md
+++ b/docsrc/docs/troubleshooting/common_issues.md
@@ -163,3 +163,8 @@ If domain lock is already disabled, also check:
 - Check [Platform-Specific Issues](/troubleshooting/platform_specific)
 - [Open an issue on GitHub](https://github.com/alamin-karno/flutter-crisp-chat/issues)
 - See the [Crisp Help Center](https://help.crisp.chat/en/) for Crisp-specific questions
+
+## Next Steps
+
+- [Platform-Specific](/troubleshooting/platform_specific) — Android, iOS, Web, and desktop troubleshooting
+- [Contributing](/community/contributing) — How to contribute to the project

--- a/docsrc/docs/troubleshooting/platform_specific.md
+++ b/docsrc/docs/troubleshooting/platform_specific.md
@@ -231,3 +231,8 @@ When using `desktop_webview_window`, add the title-bar helper to your app `main`
 - [Crisp Help Center](https://help.crisp.chat/en/)
 - [Crisp Android SDK docs](https://docs.crisp.chat/guides/chatbox-sdks/android-sdk/)
 - [Crisp iOS SDK docs](https://docs.crisp.chat/guides/chatbox-sdks/ios-sdk/)
+
+## Next Steps
+
+- [Contributing](/community/contributing) — How to contribute to the project
+- [Author & Maintainer](/community/author) — About the maintainer


### PR DESCRIPTION
- Add standardized "Next Steps" sections across community, reference, and troubleshooting documentation to improve page flow
- Update frontmatter navigation metadata for `configuration.md`, `supported_platforms.md`, `quick_start.md`, and `platform_setup.md`
- Rename "What's Next?" to "Next Steps" in `quick_start.md` for consistency
- Refine navigation links in `configuration.md` and `quick_start.md` to point to more relevant subsequent topics