### PR TITLE
Prepare v2.5.0 release changelog and align example SDK constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,25 @@ Added
 ---
 * **Web** support via the official Crisp Web Chat SDK (`$crisp` / `client.crisp.chat`).
 * **Desktop** support for **macOS**, **Windows**, and **Linux** using `desktop_webview_window`, with browser fallback when WebView is unavailable.
-* [Supported platforms](https://alamin-karno.github.io/flutter-crisp-chat/getting_started/supported_platforms) documentation and platform API matrix.
+* `FlutterCrispChat.markMessagesAsRead()` — REST `PATCH` to clear `unread.visitor` (workaround when the iOS native SDK does not sync read receipts; also usable on Android, Web, and desktop with REST credentials).
+* `FlutterCrispChat.isVideoCallsSupported()` — returns whether the **current build** supports Crisp calls (iOS WebRTC variant, or Web/desktop).
 * Optional **iOS video/audio calls** (build-time opt-in, not a runtime `CrispConfig` flag):
   * **CocoaPods:** `$CrispChatWebRTC = true` in `ios/Podfile` → links `Crisp/CrispWebRTC` instead of `Crisp/Crisp` (~10 MB larger).
   * **SPM:** `CRISP_CHAT_WEBRTC=true` before `flutter build ios` (or Xcode scheme env var); `Package.swift` selects `CrispWebRTC` automatically.
   * Android native video is not supported yet ([upstream #181](https://github.com/crisp-im/crisp-sdk-android/issues/181)); Web/desktop use the web chatbox when enabled in the Crisp dashboard.
-* `FlutterCrispChat.isVideoCallsSupported()` — returns whether the **current build** supports Crisp calls (iOS WebRTC variant, or Web/desktop).
+* Documentation: [Supported platforms](https://alamin-karno.github.io/flutter-crisp-chat/getting_started/supported_platforms) guide and platform API matrix; Crisp dashboard **domain lock** guidance ([#148](https://github.com/alamin-karno/flutter-crisp-chat/issues/148)); iOS unread-count limitation and verification ([`docs/unread-count-verification.md`](docs/unread-count-verification.md)).
 
 Changed
 ---
 * Minimum **Dart SDK 3.5.0** and **Flutter 3.24.0** (required by desktop WebView dependency).
 * `openChatboxFromNotification` and `setOnNotificationTappedCallback` are no-ops on Web/desktop.
+* Example app extended with **linux**, **macos**, and **windows** runners for multi-platform testing.
+* GitHub Actions **CI** workflow (analyze + test on Ubuntu).
+
+Breaking
+---
+* Apps on **Flutter < 3.24** or **Dart < 3.5** must stay on **2.4.8** for mobile-only usage.
+* New dependencies: `desktop_webview_window`, `http`, `url_launcher`, `web`.
 
 # 2.4.8
 

--- a/docsrc/docs/reference/changelog.md
+++ b/docsrc/docs/reference/changelog.md
@@ -22,18 +22,25 @@ All notable changes to the `crisp_chat` package are documented here. For the ful
 ## 2.5.0
 
 ### Added
-* Web support (Crisp Web Chat SDK).
+* Web support (Crisp Web Chat SDK via `client.crisp.chat`).
 * Desktop support for macOS, Windows, and Linux (`desktop_webview_window` + browser fallback).
-* [Supported platforms](/getting_started/supported_platforms) guide.
+* `FlutterCrispChat.markMessagesAsRead()` — REST `PATCH` to clear `unread.visitor` (iOS read-receipt workaround; also on Android/Web/desktop with REST credentials).
+* `FlutterCrispChat.isVideoCallsSupported()` — check whether the current build supports Crisp calls (iOS WebRTC variant, or Web/desktop).
 * Optional **iOS video/audio calls** (build-time opt-in):
   * **CocoaPods:** `$CrispChatWebRTC = true` in `ios/Podfile` (`Crisp/CrispWebRTC`, ~10 MB larger).
   * **SPM:** `CRISP_CHAT_WEBRTC=true` before build; [`Package.swift`](https://github.com/alamin-karno/flutter-crisp-chat/blob/main/ios/crisp_chat/Package.swift) selects `CrispWebRTC` automatically.
   * Android native video not supported yet ([Crisp Android SDK #181](https://github.com/crisp-im/crisp-sdk-android/issues/181)).
-* `FlutterCrispChat.isVideoCallsSupported()` — check whether the current build supports Crisp calls (iOS WebRTC variant, or Web/desktop).
+* Documentation: [Supported platforms](/getting_started/supported_platforms) guide; Crisp dashboard **domain lock** guidance ([#148](https://github.com/alamin-karno/flutter-crisp-chat/issues/148)); iOS unread-count limitation (troubleshooting and [unread messages](/core_feature/unread_messages)).
 
 ### Changed
 * Minimum Dart SDK 3.5.0 and Flutter 3.24.0.
-* Notification helpers are no-ops on Web/desktop.
+* `openChatboxFromNotification` and `setOnNotificationTappedCallback` are no-ops on Web/desktop.
+* Example app extended with **linux**, **macos**, and **windows** runners.
+* GitHub Actions **CI** (analyze + test on Ubuntu).
+
+### Breaking
+* Apps on **Flutter < 3.24** or **Dart < 3.5** must stay on **2.4.8** for mobile-only usage.
+* New dependencies: `desktop_webview_window`, `http`, `url_launcher`, `web`.
 
 ## 2.4.8
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,8 @@ description: Demonstrates how to use the flutter_crisp_chat plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: '>=3.2.6 <4.0.0'
+  sdk: '>=3.5.0 <4.0.0'
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Complete 2.5.0 changelog with markMessagesAsRead, domain-lock docs, breaking changes, and CI/example notes. Mirror on docs site. Bump example environment to Dart 3.5+ and Flutter 3.24+ to match the plugin.