### PR TITLE
Fix esbuild path traversal vulnerability (Dependabot #23)

### DIFF
--- a/docsrc/package.json
+++ b/docsrc/package.json
@@ -19,7 +19,7 @@
     "vue": "^3.5.0"
   },
   "overrides": {
-    "esbuild": "^0.28.0",
+    "esbuild": "^0.28.1",
     "@vitejs/plugin-vue": {
       "rollup": "^4.0.0"
     }


### PR DESCRIPTION
## Summary

- Bumps `esbuild` override in `docsrc/package.json` from `^0.28.0` → `^0.28.1` to address Dependabot alert #23 ([GHSA-g7r4-m6w7-qqqr](https://github.com/evanw/esbuild/security/advisories/GHSA-g7r4-m6w7-qqqr))
- Vulnerability: path traversal on Windows when serving files from `servedir` using `\\` backslash characters (Windows-only, dev server only, severity: **Low** / CVSS 2.5)
- Affected range: `>= 0.27.3, < 0.28.1` — first patched version: `0.28.1`

## Known limitation — lock file not yet updated

esbuild **v0.28.1 was released on GitHub on 2026-06-11** but has **not yet been published to npm** (latest on npm remains `0.28.0` as of 2026-06-15). Because of this:

- `package.json` declares the correct minimum: `^0.28.1`
- `package-lock.json` still resolves to `0.28.0` (cannot be regenerated until npm publish)

**Once esbuild 0.28.1 ships to npm**, regenerate the lock file before merging:
```bash
cd docsrc && npm install
```
Then commit the updated `package-lock.json` on this branch.

## Test plan

- [ ] Confirm esbuild 0.28.1 is available on npm (`npm view esbuild@0.28.1 version`)
- [ ] Run `cd docsrc && npm install` — verify it resolves to 0.28.1
- [ ] Commit updated `package-lock.json`
- [ ] Verify Dependabot alert #23 closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)