### PR TITLE
Fix SPM build error: reorder swiftSettings before linkerSettings in Package.swift

### DIFF
--- a/ios/crisp_chat/Package.swift
+++ b/ios/crisp_chat/Package.swift
@@ -53,7 +53,10 @@ let package = Package(
                 .product(name: crispSdkProduct, package: "crisp-sdk-ios")
             ],
             path: "Sources/crisp_chat",
-            swiftSettings: crispChatSwiftSettings
+            swiftSettings: crispChatSwiftSettings,
+            linkerSettings: [
+                .linkedFramework("UIKit")
+            ]
         )
     ]
 )


### PR DESCRIPTION
## Problem

Building with Swift Package Manager failed with:
error: argument 'swiftSettings' must precede argument 'linkerSettings'

The `.target()` initializer in `ios/crisp_chat/Package.swift` had `linkerSettings` before `swiftSettings`, which violates SPM's required argument ordering.

## Fix

Swapped the argument order so `swiftSettings` precedes `linkerSettings`:

```swift
// Before
linkerSettings: [.linkedFramework("UIKit")],
swiftSettings: crispChatSwiftSettings

// After  
swiftSettings: crispChatSwiftSettings,
linkerSettings: [.linkedFramework("UIKit")]

```
Root cause
This was introduced during merge conflict resolution — the upstream branch added swiftSettings for WebRTC opt-in support, while this branch added linkerSettings for UIKit linking. When combined, the arguments ended up in the wrong order. 